### PR TITLE
Installation of pybind11 in setup.py

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,7 +33,6 @@ build_script:
 - cmake --build . --config %CMAKE_CONFIG%
 - cmake --build . --config %CMAKE_CONFIG% --target check
 - py -c "import sys; print(sys.version+'\n'+sys.executable)"
-- py -m pip install pybind11
 - if not defined USE_PIP (py setup.py install)
 - cmd: '"%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" %ARCH%'
 - if     defined USE_PIP (py -m pip install --upgrade .)

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,6 @@ matrix:
 install:
 - |
   $PYTHON -m pip --version || $PYTHON -m ensurepip --user
-  $PYTHON -m pip install --user pybind11
-  $PYTHON -c "import pybind11; print('headers: ' + pybind11.get_include(True))"
 script:
   - $COMPILER --version
   - CXX=$COMPILER cmake .

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ __version__ = read_version_from_header()
 
 class get_pybind_include(object):
     """Helper class to determine the pybind11 include path
-
     The purpose of this class is to postpone importing pybind11
     until it is actually installed, so that the ``get_include()``
     method can be invoked. """
@@ -30,23 +29,7 @@ class get_pybind_include(object):
         self.user = user
 
     def __str__(self):
-        # We should have pybind11 installed by now, but old pip
-        # before https://github.com/pypa/pip/pull/2616
-        # would not handle dependencies properly.
-        # So in such case at least hint a workaround to the user.
-        try:
-            import pybind11
-        except ImportError:
-            print('\n' + 50*'*')
-            print('*****  Please try to install pybind11 first  *****')
-            print(50*'*' + '\n')
-            sys.exit(1)
-        if pybind11.__version__ < MIN_PYBIND_VER:
-            print('\n' + 50*'*')
-            print('Use pybind11 >= %s.' % MIN_PYBIND_VER)
-            print('You have pybind11 %s in %s'
-                  % (pybind11.__version__, os.path.dirname(pybind11.__file__)))
-            sys.exit(1)
+        import pybind11
         return pybind11.get_include(self.user)
 
 if USE_SYSTEM_ZLIB:
@@ -166,6 +149,7 @@ setup(
     packages=['gemmi-examples'],
     package_dir={'gemmi-examples': 'examples'},
     install_requires=['pybind11>=' + MIN_PYBIND_VER],
+    setup_requires=['pybind11>=' + MIN_PYBIND_VER],
     cmdclass={'build_ext': BuildExt},
     zip_safe=False,
     license='MPL-2.0',


### PR DESCRIPTION
The `setup.py` included with gemmi requires the user to pre-install pybind11 if it is missing, or does not meet the minimum version requirement. This pull request updates the `setup.py` to automatically install pybind11 if it is missing from the environment prior to installing gemmi. 

The updates made to the `setup.py` file are based on this [example](https://github.com/pybind/python_example/blob/master/setup.py). The important change is to include a `setup_requires` argument in the main `setup()` call. I have also updated the `get_pybind_include` object to match the example. 

The final changes made in this pull request are to the CI .yml scripts for appveyor / TravisCI. I removed the manual `pip install pybind11` calls so that it will be possible to see the effects of these changes. 

I look forward to your thoughts!

Best,
Jack