### PR TITLE
Reduce number of C++ signatures in generated docstrings

### DIFF
--- a/python/cif.cpp
+++ b/python/cif.cpp
@@ -17,6 +17,13 @@ void cif_parse_string(Document& doc, const std::string& data);
 void cif_parse_file(Document& doc, const std::string& filename);
 
 void add_cif(py::module& cif) {
+  py::class_<Block> pyCifBlock(cif, "Block");
+  py::class_<Item> pyCifItem(cif, "Item");
+  py::class_<Loop> lp(cif, "Loop");
+  py::class_<Column> pyCifColumn(cif, "Column");
+  py::class_<Table> lt(cif, "Table");
+  py::class_<Table::Row> pyCifTableRow(lt, "Row");
+
   py::enum_<Style>(cif, "Style")
     .value("Simple", Style::Simple)
     .value("NoBlankLines", Style::NoBlankLines)
@@ -111,7 +118,7 @@ void add_cif(py::module& cif) {
         return s;
     });
 
-  py::class_<Block>(cif, "Block")
+  pyCifBlock
     .def(py::init<const std::string &>())
     .def_readwrite("name", &Block::name)
     .def("__iter__", [](Block& self) { return py::make_iterator(self.items); },
@@ -215,7 +222,8 @@ void add_cif(py::module& cif) {
         return gemmi::tostr("<gemmi.cif.Block ", self.name, '>');
     });
 
-  py::class_<Item> (cif, "Item")
+
+  pyCifItem
     .def("erase", &Item::erase)
     .def_readonly("line_number", &Item::line_number)
     .def_property_readonly("pair", [](Item& self) {
@@ -229,7 +237,6 @@ void add_cif(py::module& cif) {
     }, py::return_value_policy::reference_internal)
     ;
 
-  py::class_<Loop> lp(cif, "Loop");
   lp.def(py::init<>())
     .def("width", &Loop::width, "Returns number of columns")
     .def("length", &Loop::length, "Returns number of rows")
@@ -243,7 +250,8 @@ void add_cif(py::module& cif) {
                             self.width(), '>');
     });
 
-  py::class_<Column>(cif, "Column")
+
+  pyCifColumn
     .def(py::init<>())
     .def("get_loop", &Column::get_loop,
          py::return_value_policy::reference_internal)
@@ -263,7 +271,6 @@ void add_cif(py::module& cif) {
         return "<gemmi.cif.Column " + desc + ">";
     });
 
-  py::class_<Table> lt(cif, "Table");
   lt.def("width", &Table::width)
     .def_readonly("prefix_length", &Table::prefix_length)
     .def_property_readonly("loop", &Table::get_loop,
@@ -292,7 +299,7 @@ void add_cif(py::module& cif) {
                ">";
     });
 
-  py::class_<Table::Row>(lt, "Row")
+  pyCifTableRow
     .def("str", &Table::Row::str)
     .def("__len__", &Table::Row::size)
     .def("__getitem__", (std::string& (Table::Row::*)(int)) &Table::Row::at)

--- a/python/gemmi.cpp
+++ b/python/gemmi.cpp
@@ -27,6 +27,7 @@ void add_misc(py::module& m) {
   using gemmi::Element;
   using gemmi::SmallStructure;
   using IT92 = gemmi::IT92<double>;
+  py::class_<IT92::Coef> pyIT92Coef(m, "IT92Coef");
   py::class_<Element>(m, "Element")
     .def(py::init<const std::string &>())
     .def(py::init<int>())
@@ -88,7 +89,7 @@ void add_misc(py::module& m) {
         return "<gemmi.SmallStructure: " + std::string(self.name) + ">";
     });
 
-  py::class_<IT92::Coef>(m, "IT92Coef")
+  pyIT92Coef
     .def("calculate_sf", &IT92::Coef::calculate_sf, py::arg("stol2"))
     .def("calculate_density_iso", &IT92::Coef::calculate_density_iso,
          py::arg("r2"), py::arg("B"))
@@ -114,17 +115,17 @@ void add_misc(py::module& m) {
 PYBIND11_MODULE(gemmi, mg) {
   mg.doc() = "GEneral MacroMolecular I/O";
   mg.attr("__version__") = GEMMI_VERSION;
+  py::module cif = mg.def_submodule("cif", "CIF file format");
+  add_cif(cif);
   add_symmetry(mg);
-  add_grid(mg);
   add_unitcell(mg);
-  add_hkl(mg);
   add_misc(mg);
   add_mol(mg);
+  add_grid(mg);
+  add_cif_read(cif);
+  add_hkl(mg);
   add_monlib(mg);
   add_alignment(mg);
   add_select(mg);
   add_read_structure(mg);
-  py::module cif = mg.def_submodule("cif", "CIF file format");
-  add_cif(cif);
-  add_cif_read(cif);
 }

--- a/python/mol.cpp
+++ b/python/mol.cpp
@@ -95,6 +95,20 @@ expand_protein_one_letter_string(const std::string& s) {
 }
 
 void add_mol(py::module& m) {
+
+  // "Forward declaration" of python classes to avoid
+  // C++ signatures in docstrings
+  py::class_<AtomAddress> pyAtomAddress(m, "AtomAddress");
+  py::class_<ResidueId> pyResidueId(m, "ResidueId");
+  py::class_<Atom> pyAtom(m, "Atom");
+  py::class_<Residue, ResidueId> pyResidue(m, "Residue");
+  py::class_<Chain> pyChain(m, "Chain");
+  py::class_<Model> pyModel(m, "Model");
+  py::class_<SeqId> pySeqId(m, "SeqId");
+  py::class_<ResidueSpan> pyResidueSpan(m, "ResidueSpan");
+  py::class_<ResidueGroup, ResidueSpan> pyResidueGroup(m, "ResidueGroup");
+  py::class_<CraProxy> pyCraGenerator(m, "CraGenerator");
+
   py::class_<ResidueInfo>(m, "ResidueInfo")
     .def_readonly("one_letter_code", &ResidueInfo::one_letter_code)
     .def_readonly("hydrogen_count", &ResidueInfo::hydrogen_count)
@@ -300,7 +314,7 @@ void add_mol(py::module& m) {
                      self.models.size(), " model(s)>");
     });
 
-  py::class_<AtomAddress>(m, "AtomAddress")
+  pyAtomAddress
     .def(py::init<>())
     .def(py::init<const Chain&, const Residue&, const Atom&>())
     .def(py::init<const std::string&, const SeqId&, const std::string&,
@@ -325,7 +339,7 @@ void add_mol(py::module& m) {
         return tostr("<gemmi.CRA ", atom_str(self), '>');
     });
 
-  py::class_<Model>(m, "Model")
+  pyModel
     .def(py::init<std::string>())
     .def_readwrite("name", &Model::name)
     .def("__len__", [](const Model& self) { return self.chains.size(); })
@@ -399,11 +413,11 @@ void add_mol(py::module& m) {
         return py::make_iterator(self);
     }, py::keep_alive<0, 1>());
 
-  py::class_<CraProxy>(m, "CraGenerator")
+  pyCraGenerator
     .def("__iter__", [](CraProxy& self) { return py::make_iterator(self); },
          py::keep_alive<0, 1>());
 
-  py::class_<Chain>(m, "Chain")
+  pyChain
     .def(py::init<std::string>())
     .def_readwrite("name", &Chain::name)
     .def("__len__", [](const Chain& ch) { return ch.residues.size(); })
@@ -455,7 +469,7 @@ void add_mol(py::module& m) {
                      " with ", self.residues.size(), " res>");
     });
 
-  py::class_<ResidueSpan>(m, "ResidueSpan")
+  pyResidueSpan
     .def("__len__", &ResidueSpan::size)
     .def("__iter__", [](ResidueSpan& g) { return py::make_iterator(g); },
          py::keep_alive<0, 1>())
@@ -499,7 +513,7 @@ void add_mol(py::module& m) {
         return r + "]>";
     });
 
-  py::class_<ResidueGroup, ResidueSpan>(m, "ResidueGroup")
+  pyResidueGroup
     // need to duplicate it so it is visible
     .def("__getitem__", [](ResidueGroup& g, int index) -> Residue& {
         return g[normalize_index(index, g)];
@@ -529,7 +543,7 @@ void add_mol(py::module& m) {
                      self.size(), '>');
     });
 
-  py::class_<SeqId>(m, "SeqId")
+  pySeqId
     .def(py::init<int, char>())
     .def(py::init<const std::string&>())
     .def_readwrite("num", &SeqId::num)
@@ -539,7 +553,7 @@ void add_mol(py::module& m) {
         return tostr("<gemmi.SeqId ", self.str(), '>');
     });
 
-  py::class_<ResidueId>(m, "ResidueId")
+  pyResidueId
     .def(py::init<>())
     .def_readwrite("name", &ResidueId::name)
     .def_readwrite("seqid", &ResidueId::seqid)
@@ -549,7 +563,7 @@ void add_mol(py::module& m) {
         return tostr("<gemmi.ResidueId ", self.str(), '>');
     });
 
-  py::class_<Residue, ResidueId>(m, "Residue")
+  pyResidue
     .def(py::init<>())
     .def_readwrite("subchain", &Residue::subchain)
     .def_readwrite("entity_type", &Residue::entity_type)
@@ -592,7 +606,7 @@ void add_mol(py::module& m) {
                      self.atoms.size(), " atoms>");
     });
 
-  py::class_<Atom>(m, "Atom")
+  pyAtom
     .def(py::init<>())
     .def_readwrite("name", &Atom::name)
     .def_readwrite("altloc", &Atom::altloc)

--- a/python/monlib.cpp
+++ b/python/monlib.cpp
@@ -29,6 +29,22 @@ PYBIND11_MAKE_OPAQUE(links_type)
 PYBIND11_MAKE_OPAQUE(modifications_type)
 
 void add_monlib(py::module& m) {
+
+  py::class_<ChemMod> pyChemMod(m, "ChemMod");
+  py::class_<ChemLink> chemlink(m, "ChemLink");
+  py::class_<ChemComp> chemcomp(m, "ChemComp");
+
+  py::class_<ChemLink::Side> pyChemLinkSide(chemlink, "Side");
+
+  py::class_<Restraints> restraints(m, "Restraints");
+  py::class_<Restraints::Bond> pyRestraintsBond(restraints, "Bond");
+
+  py::class_<Topo> topo(m, "Topo");
+  py::class_<Topo::Bond> pyTopoBond(topo, "Bond");
+  py::class_<Topo::ExtraLink> pyTopoExtraLink(topo, "ExtraLink");
+
+  py::class_<ChemComp::Atom> pyChemCompAtom(chemcomp, "Atom");
+
   py::bind_vector<std::vector<Restraints::Bond>>(m, "RestraintsBonds");
   py::bind_vector<std::vector<ChemComp::Atom>>(m, "ChemCompAtoms");
   py::bind_vector<std::vector<Topo::Bond>>(m, "TopoBonds");
@@ -46,7 +62,7 @@ void add_monlib(py::module& m) {
     .value("Deloc", BondType::Deloc)
     .value("Metal", BondType::Metal);
 
-  py::class_<Restraints> restraints(m, "Restraints");
+
   py::class_<Restraints::AtomId>(restraints, "AtomId")
     .def_readwrite("comp", &Restraints::AtomId::comp)
     .def_readwrite("atom", &Restraints::AtomId::atom)
@@ -56,7 +72,7 @@ void add_monlib(py::module& m) {
          py::arg("res1"), py::arg("res2"), py::arg("altloc"),
          py::return_value_policy::reference)
     ;
-  py::class_<Restraints::Bond>(restraints, "Bond")
+  pyRestraintsBond
     .def_readwrite("id1", &Restraints::Bond::id1)
     .def_readwrite("id2", &Restraints::Bond::id2)
     .def_readwrite("type", &Restraints::Bond::type)
@@ -82,8 +98,7 @@ void add_monlib(py::module& m) {
          }, py::return_value_policy::reference_internal)
     ;
 
-  py::class_<ChemComp> chemcomp(m, "ChemComp");
-  py::class_<ChemComp::Atom>(chemcomp, "Atom")
+  pyChemCompAtom
     .def_readonly("id", &ChemComp::Atom::id)
     .def_readonly("el", &ChemComp::Atom::el)
     .def_readonly("charge", &ChemComp::Atom::charge)
@@ -100,7 +115,6 @@ void add_monlib(py::module& m) {
     ;
   m.def("make_chemcomp_from_block", &make_chemcomp_from_block);
 
-  py::class_<ChemLink> chemlink(m, "ChemLink");
   chemlink
     .def_readwrite("id", &ChemLink::id)
     .def_readwrite("name", &ChemLink::name)
@@ -110,7 +124,9 @@ void add_monlib(py::module& m) {
     .def("__repr__", [](const ChemLink& self) {
         return "<gemmi.ChemLink " + self.id + ">";
     });
-  py::class_<ChemLink::Side>(chemlink, "Side")
+
+
+  pyChemLinkSide
     .def_readwrite("comp", &ChemLink::Side::comp)
     .def_readwrite("mod", &ChemLink::Side::mod)
     .def_readwrite("group", &ChemLink::Side::group)
@@ -119,7 +135,7 @@ void add_monlib(py::module& m) {
                ChemLink::group_str(self.group) + ">";
     });
 
-  py::class_<ChemMod>(m, "ChemMod")
+  pyChemMod
     .def_readwrite("id", &ChemMod::id)
     .def("__repr__", [](const ChemLink& self) {
         return "<gemmi.ChemMod " + self.id + ">";
@@ -141,14 +157,13 @@ void add_monlib(py::module& m) {
                std::to_string(self.modifications.size()) + " modifications>";
     });
 
-  py::class_<Topo> topo(m, "Topo");
-  py::class_<Topo::Bond>(topo, "Bond")
+  pyTopoBond
     .def_readonly("restr", &Topo::Bond::restr)
     .def_readonly("atoms", &Topo::Bond::atoms)
     .def("calculate", &Topo::Bond::calculate)
     .def("calculate_z", &Topo::Bond::calculate_z)
     ;
-  py::class_<Topo::ExtraLink>(topo, "ExtraLink")
+  pyTopoExtraLink
     .def_readonly("res1", &Topo::ExtraLink::res1)
     .def_readonly("res2", &Topo::ExtraLink::res2)
     .def_readonly("alt1", &Topo::ExtraLink::alt1)
@@ -185,6 +200,9 @@ void add_monlib(py::module& m) {
     ;
 
   py::class_<ContactSearch> contactsearch(m, "ContactSearch");
+  py::class_<ContactSearch::Result> pyContactSearchResult(contactsearch, "Result");
+  py::enum_<ContactSearch::Ignore> pyContactSearchIgnore(contactsearch, "Ignore");
+
   contactsearch
     .def(py::init<float>())
     .def_readwrite("search_radius", &ContactSearch::search_radius)
@@ -202,14 +220,14 @@ void add_monlib(py::module& m) {
     .def("find_contacts", &ContactSearch::find_contacts)
     ;
 
-  py::enum_<ContactSearch::Ignore>(contactsearch, "Ignore")
+  pyContactSearchIgnore
     .value("Nothing", ContactSearch::Ignore::Nothing)
     .value("SameResidue", ContactSearch::Ignore::SameResidue)
     .value("AdjacentResidues", ContactSearch::Ignore::AdjacentResidues)
     .value("SameChain", ContactSearch::Ignore::SameChain)
     .value("SameAsu", ContactSearch::Ignore::SameAsu);
 
-  py::class_<ContactSearch::Result>(contactsearch, "Result")
+  pyContactSearchResult
     .def_readonly("partner1", &ContactSearch::Result::partner1)
     .def_readonly("partner2", &ContactSearch::Result::partner2)
     .def_readonly("image_idx", &ContactSearch::Result::image_idx)
@@ -219,6 +237,7 @@ void add_monlib(py::module& m) {
     ;
 
   py::class_<LinkHunt> linkhunt(m, "LinkHunt");
+  py::class_<LinkHunt::Match> pyLinkHuntMatch(linkhunt, "Match");
   linkhunt
     .def(py::init<>())
     .def("index_chem_links", &LinkHunt::index_chem_links,
@@ -227,7 +246,8 @@ void add_monlib(py::module& m) {
          py::arg("st"), py::arg("bond_margin"), py::arg("radius_margin"),
          py::arg("ignore")=ContactSearch::Ignore::SameResidue)
     ;
-  py::class_<LinkHunt::Match>(linkhunt, "Match")
+
+  pyLinkHuntMatch
     .def_readonly("chem_link", &LinkHunt::Match::chem_link)
     .def_readonly("chem_link_count", &LinkHunt::Match::chem_link_count)
     .def_readonly("cra1", &LinkHunt::Match::cra1)
@@ -239,8 +259,14 @@ void add_monlib(py::module& m) {
 }
 
 void add_select(py::module& m) {
+  py::class_<Selection> pySelection(m, "Selection");
+  py::class_<FilterProxy<Selection, Model>> pySelectionModelsProxy(m, "SelectionModelsProxy");
+  py::class_<FilterProxy<Selection, Chain>> pySelectionChainsProxy(m, "SelectionChainsProxy");
+  py::class_<FilterProxy<Selection, Residue>> pySelectionResidusProxy(m, "SelectionResidusProxy");
+  py::class_<FilterProxy<Selection, Atom>> pySelectionAtomsProxy(m, "SelectionAtomsProxy");
+
   m.def("parse_cid", &parse_cid);
-  py::class_<Selection>(m, "Selection")
+  pySelection
     .def("models", &Selection::models)
     .def("chains", &Selection::chains)
     .def("residues", &Selection::residues)
@@ -254,22 +280,22 @@ void add_select(py::module& m) {
         return "<gemmi.Selection CID: " + self.to_cid() + ">";
     });
 
-    py::class_<FilterProxy<Selection, Model>>(m, "SelectionModelsProxy")
+    pySelectionModelsProxy
     .def("__iter__", [](FilterProxy<Selection, Model>& self) {
         return py::make_iterator(self);
     }, py::keep_alive<0, 1>());
 
-    py::class_<FilterProxy<Selection, Chain>>(m, "SelectionChainsProxy")
+    pySelectionChainsProxy
     .def("__iter__", [](FilterProxy<Selection, Chain>& self) {
         return py::make_iterator(self);
     }, py::keep_alive<0, 1>());
 
-    py::class_<FilterProxy<Selection, Residue>>(m, "SelectionResidusProxy")
+    pySelectionResidusProxy
     .def("__iter__", [](FilterProxy<Selection, Residue>& self) {
         return py::make_iterator(self);
     }, py::keep_alive<0, 1>());
 
-    py::class_<FilterProxy<Selection, Atom>>(m, "SelectionAtomsProxy")
+    pySelectionAtomsProxy
     .def("__iter__", [](FilterProxy<Selection, Atom>& self) {
         return py::make_iterator(self);
     }, py::keep_alive<0, 1>());

--- a/python/monlib.cpp
+++ b/python/monlib.cpp
@@ -324,12 +324,12 @@ void add_alignment(py::module& m) {
   m.def("prepare_blosum62_scoring", &prepare_blosum62_scoring);
   m.def("align_string_sequences", &align_string_sequences,
         py::arg("query"), py::arg("target"), py::arg("free_gapo"),
-        py::arg("scoring")=AlignmentScoring());
+        py::arg_v("scoring", AlignmentScoring(), "gemmi.AlignmentScoring()"));
   m.def("align_sequence_to_polymer",
         [](const std::vector<std::string>& full_seq,
            const ResidueSpan& polymer, PolymerType polymer_type,
            AlignmentScoring& sco) {
       return align_sequence_to_polymer(full_seq, polymer, polymer_type, sco);
   }, py::arg("full_seq"), py::arg("polymer"), py::arg("polymer_type"),
-     py::arg("scoring")=AlignmentScoring());
+     py::arg_v("scoring", AlignmentScoring(), "gemmi.AlignmentScoring()"));
 }

--- a/python/unitcell.cpp
+++ b/python/unitcell.cpp
@@ -88,8 +88,8 @@ void add_unitcell(py::module& m) {
                "             [" + triple(a[2][0], a[2][1], a[2][2]) + "]>";
     });
 
-  add_smat33<float>(m, "SMat33f");
   add_smat33<double>(m, "SMat33d");
+  add_smat33<float>(m, "SMat33f");
 
   py::class_<Transform>(m, "Transform")
     .def(py::init<>())


### PR DESCRIPTION
Valid signatures in docstrings are crucial for static analysis tools and doc generators. 

[this PR]:

```
$ python show_gemmi_help.py | grep '::' | wc -l
0
```

[master]:

```
$ python show_gemmi_help.py | grep '::' | wc -l
358
```


<details><summary> [master] <code>python show_gemmi_help.py | grep '::' | head</code></summary>

```
     |      make_assembly(self: gemmi.Assembly, arg0: gemmi::Model, arg1: gemmi.HowToNameCopiedChains) -> gemmi::Model
     |      2. __init__(self: gemmi.AtomAddress, arg0: gemmi::Chain, arg1: gemmi::Residue, arg2: gemmi::Atom) -> None
     |      3. __init__(self: gemmi.AtomAddress, chain: str, seqid: gemmi::SeqId, resname: str, atom: str, altloc: str = '\x00') -> None
     |      1. __getitem__(self: gemmi.AtomGroup, index: int) -> gemmi::Atom
     |      2. __getitem__(self: gemmi.AtomGroup, altloc: str) -> gemmi::Atom
     |      1. __getitem__(self: gemmi.Chain, pdb_seqid: str) -> gemmi::ResidueGroup
     |      2. __getitem__(self: gemmi.Chain, index: int) -> gemmi::Residue
     |      add_residue(self: gemmi.Chain, residue: gemmi::Residue, pos: int = -1) -> gemmi::Residue
     |      append_residues(self: gemmi.Chain, new_residues: List[gemmi::Residue], min_sep: int = 0) -> None
     |      get_ligands(self: gemmi.Chain) -> gemmi::ResidueSpan
```

</details>


<details><summary><code>show_gemmi_help.py</code></summary>

```python

import gemmi
import inspect

_visited = []


def recursive_help(obj):
    if obj in _visited: return
    _visited.append(obj)
    help(obj)
    for name in dir(obj):
        if hasattr(obj, name):
            attr = getattr(obj, name)
            if inspect.isclass(attr) or inspect.ismodule(attr):
                recursive_help(attr)


recursive_help(gemmi)

```

</details>
