### PR TITLE
Avoid union of TER-separated chains 

### DIFF
--- a/include/gemmi/pdb.hpp
+++ b/include/gemmi/pdb.hpp
@@ -529,7 +529,7 @@ Structure read_pdb_from_line_input(Input&& infile, const std::string& source,
       model = nullptr;
       chain = nullptr;
 
-    } else if (is_record_type(line, "TER")) { // finishes polymer chains
+    } else if (starts_with(line, "TER")) { // finishes polymer chains
       // we don't expect more than one TER record in one chain
       if (!chain || after_ter)
         continue;

--- a/include/gemmi/pdb.hpp
+++ b/include/gemmi/pdb.hpp
@@ -318,8 +318,7 @@ Structure read_pdb_from_line_input(Input&& infile, const std::string& source,
           model = &st.models.back();
         }
         const Chain* prev_part = model->find_chain(chain_name);
-        after_ter = prev_part &&
-                    prev_part->residues[0].entity_type == EntityType::Polymer;
+        after_ter = false;
         model->chains.emplace_back(chain_name);
         chain = &model->chains.back();
         resi = nullptr;
@@ -536,6 +535,7 @@ Structure read_pdb_from_line_input(Input&& infile, const std::string& source,
       for (Residue& res : chain->residues)
         res.entity_type = EntityType::Polymer;
       after_ter = true;
+      chain = nullptr;
     } else if (is_record_type(line, "SCALEn")) {
       if (read_matrix(matrix, line, len) == 3) {
         st.cell.set_matrices_from_fract(matrix);


### PR DESCRIPTION
I'm not sure about this PR, since it changes how gemmis interpret pdb files. 

For example [1UBQ](https://www.rcsb.org/structure/1UBQ) structure reads as two chains instead of one:
```
# master
<gemmi.Chain A with 134 res>
# this PR
<gemmi.Chain A with 76 res>
<gemmi.Chain A with 58 res>
```

TBH I didn't get whole logic of pdb parsing, especially the idea of `after_ter` variable, so I might did something totally wrong. 


Close #35 