### PR TITLE
return P1 space group when number 0 requested

### DIFF
--- a/include/gemmi/symmetry.hpp
+++ b/include/gemmi/symmetry.hpp
@@ -1646,6 +1646,8 @@ const char Tables_<Dummy>::ccp4_hkl_asu[230] = {
 using spacegroup_tables = impl::Tables_<void>;
 
 inline const SpaceGroup* find_spacegroup_by_number(int ccp4) noexcept {
+  if (ccp4 == 0)
+    return &spacegroup_tables::main[0];
   for (const SpaceGroup& sg : spacegroup_tables::main)
     if (sg.ccp4 == ccp4)
       return &sg;


### PR DESCRIPTION
It returned "P 2 1 1" when e.g. mrc file (space group header: 0) was opened. This would be not what is expected.