### PR TITLE
Add virtual destructor for Vec3

### DIFF
--- a/include/gemmi/math.hpp
+++ b/include/gemmi/math.hpp
@@ -46,6 +46,7 @@ struct Vec3 {
 
   Vec3() : x(0), y(0), z(0) {}
   Vec3(double x_, double y_, double z_) : x(x_), y(y_), z(z_) {}
+  virtual ~Vec3() = default;
 
   double& at(int i) {
     switch (i) {


### PR DESCRIPTION
for automatic downcasting in python binding
https://pybind11.readthedocs.io/en/stable/classes.html#inheritance-and-automatic-downcasting

This allows for example `cra.pos.atom += vec3`. If there is any unwanted side effect please let me know.