### PR TITLE
Add python binding for Structure::raw_remarks

### DIFF
--- a/python/mol.cpp
+++ b/python/mol.cpp
@@ -107,6 +107,7 @@ void add_mol(py::module& m) {
     .def_readwrite("connections", &Structure::connections)
     .def_readwrite("assemblies", &Structure::assemblies)
     .def_readwrite("info", &Structure::info)
+    .def_readwrite("raw_remarks", &Structure::raw_remarks)
     .def("get_entity",
          (Entity* (Structure::*)(const std::string&)) &Structure::get_entity,
          py::arg("subchain"), py::return_value_policy::reference_internal)


### PR DESCRIPTION
I wanted this for keeping metadata (e.g. read structure from refmac mmcif, add raw_remarks from pdb, and write both pdb/mmcif).