### PR TITLE
Add pickling support to SpaceGroup and UnitCell

### DIFF
--- a/python/sym.cpp
+++ b/python/sym.cpp
@@ -186,7 +186,15 @@ void add_symmetry(py::module& m) {
     }, py::arg("miller_array").noconvert())
     .def("__repr__", [](const SpaceGroup &self) {
         return "<gemmi.SpaceGroup(\"" + self.xhm() + "\")>";
-    });
+    })
+    .def(py::pickle(
+        [](const SpaceGroup &self) {
+          return self.xhm();
+        },
+        [](const std::string &s) {
+          return const_cast<SpaceGroup*>(&get_spacegroup_by_name(s));
+        }
+    ));
 
   py::class_<ReciprocalAsu>(m, "ReciprocalAsu")
     .def(py::init<const SpaceGroup*>())

--- a/python/unitcell.cpp
+++ b/python/unitcell.cpp
@@ -268,5 +268,14 @@ void add_unitcell(py::module& m) {
     .def("__repr__", [](const UnitCell& self) {
         return "<gemmi.UnitCell(" + triple(self.a, self.b, self.c)
              + ", " + triple(self.alpha, self.beta, self.gamma) + ")>";
-    });
+    })
+    .def(py::pickle(
+         [](const UnitCell &self) {
+           return py::make_tuple(self.a, self.b, self.c, self.alpha, self.beta, self.gamma);
+         },
+         [](const py::tuple p) {
+           UnitCell uc(p[0].cast<double>(), p[1].cast<double>(), p[2].cast<double>(), p[3].cast<double>(), p[4].cast<double>(), p[5].cast<double>());
+           return uc;
+         }
+    ));
 }

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -297,5 +297,21 @@ class TestSymmetry(unittest.TestCase):
         self.assertEqual(gops.epsilon_factor([3,3,3]), 12)
         self.assertEqual(gops.epsilon_factor_without_centering([2,0,0]), 4)
 
+    def test_pickling(self):
+        import os
+        try:
+            import cPickle as pickle  # Use cPickle on Python 2.7
+        except ImportError:
+            import pickle
+            
+        sg =  gemmi.SpaceGroup("P 31 2 1")
+        with open("temp.pkl", "wb") as temp:
+            pickle.dump(sg, temp)
+        with open("temp.pkl", "rb") as temp:
+            result = pickle.load(temp)
+        self.assertTrue(isinstance(result, gemmi.SpaceGroup))
+        self.assertEqual(sg.xhm(), result.xhm())
+        os.remove("temp.pkl")
+    
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_unitcell.py
+++ b/tests/test_unitcell.py
@@ -101,6 +101,22 @@ class TestUnitCell(unittest.TestCase):
         for a, b in zip(site.aniso.elements(), ucif):
             self.assertAlmostEqual(a, b, delta=1e-6)
 
+    def test_pickling(self):
+        import os
+        try:
+            import cPickle as pickle  # Use cPickle on Python 2.7
+        except ImportError:
+            import pickle
+
+        cell = UnitCell(35.996, 41.601, 45.756, 67.40, 66.90, 74.85)
+        with open("temp.pkl", "wb") as temp:
+            pickle.dump(cell, temp)
+        with open("temp.pkl", "rb") as temp:
+            result = pickle.load(temp)
+        self.assertTrue(isinstance(result, UnitCell))
+        self.assertEqual(cell.parameters, result.parameters)
+        os.remove("temp.pkl")
+        
 class TestAngles(unittest.TestCase):
     def test_dihedral_special_cases(self):
         a = Position(random(), random(), random())


### PR DESCRIPTION
I've been curious about adding pickling support to a few of the `gemmi` classes that are used in `reciprocalspaceship` to allow us to pickle our `DataSet` objects. My revisions to the python interface are based on https://pybind11.readthedocs.io/en/stable/advanced/classes.html#pickling-support.

This seems to mostly work -- however, on my fork it seems to be failing CI in Ubuntu 16.04/Clang 3.5. Please let me know if you have any thoughts on what seems to be going on. 