### PR TITLE
add default_scale option to adjust_hydrogen_distances()

### DIFF
--- a/include/gemmi/placeh.hpp
+++ b/include/gemmi/placeh.hpp
@@ -346,7 +346,7 @@ inline void place_hydrogens(const Atom& atom, Topo::ResInfo& ri,
   }
 }
 
-inline void adjust_hydrogen_distances(Topo& topo, Restraints::DistanceOf of) {
+inline void adjust_hydrogen_distances(Topo& topo, Restraints::DistanceOf of, double default_scale=1.) {
   for (Topo::ChainInfo& chain_info : topo.chain_infos)
     for (Topo::ResInfo& ri : chain_info.res_infos)
       for (const Topo::Force& force : ri.forces)
@@ -356,12 +356,11 @@ inline void adjust_hydrogen_distances(Topo& topo, Restraints::DistanceOf of) {
           if (t.atoms[0]->is_hydrogen() || t.atoms[1]->is_hydrogen()) {
             Position u = t.atoms[1]->pos - t.atoms[0]->pos;
             double scale = t.restr->distance(of) / u.length();
-            if (!std::isnan(scale)) {
-              if (t.atoms[1]->is_hydrogen())
-                t.atoms[1]->pos = t.atoms[0]->pos + u * scale;
-              else
-                t.atoms[0]->pos = t.atoms[1]->pos - u * scale;
-            }
+            if (std::isnan(scale)) scale = default_scale;
+            if (t.atoms[1]->is_hydrogen())
+              t.atoms[1]->pos = t.atoms[0]->pos + u * scale;
+            else
+              t.atoms[0]->pos = t.atoms[1]->pos - u * scale;
           }
         }
 }

--- a/python/topo.cpp
+++ b/python/topo.cpp
@@ -73,7 +73,8 @@ void add_topo(py::module& m) {
 
   topo
     .def(py::init<>())
-    .def("adjust_hydrogen_distances", &adjust_hydrogen_distances)
+    .def("adjust_hydrogen_distances", &adjust_hydrogen_distances,
+         py::arg("of"), py::arg("default_scale")=1.)
     .def_readonly("bonds", &Topo::bonds)
     .def_readonly("angles", &Topo::angles)
     .def_readonly("torsions", &Topo::torsions)


### PR DESCRIPTION
It would be convenient in case nucleus distances are not available in the monomer library. A good scale would be ~1.1 to electron distances.