### PR TITLE
Fix to add hydrogens to all altlocs

### DIFF
--- a/include/gemmi/placeh.hpp
+++ b/include/gemmi/placeh.hpp
@@ -38,7 +38,6 @@ inline void add_hydrogens_without_positions(const ChemComp& cc, Residue& res) {
           // calc_flag will be changed to Calculated when the position is set
           atom.calc_flag = CalcFlag::Dummy;
           res.atoms.push_back(atom);
-          break;
         }
   }
 }


### PR DESCRIPTION
Currently gemmi only adds hydrogen to the first altloc.