### PR TITLE
chirality_from_string: support "."

### DIFF
--- a/include/gemmi/chemcomp.hpp
+++ b/include/gemmi/chemcomp.hpp
@@ -436,6 +436,7 @@ inline ChiralityType chirality_from_string(const std::string& s) {
     case 'p': return ChiralityType::Positive;
     case 'n': return ChiralityType::Negative;
     case 'b': return ChiralityType::Both;
+    case '.': return ChiralityType::Both;
     default: throw std::out_of_range("Unexpected chirality: " + s);
   }
 }


### PR DESCRIPTION
CCP4 7.1.016 introduced the following modification in mon_lib_list.cif, which could not be parsed by gemmi.
```
loop_
_chem_mod_chir.mod_id
_chem_mod_chir.function
_chem_mod_chir.atom_id_centre
_chem_mod_chir.atom_id_1
_chem_mod_chir.atom_id_2
_chem_mod_chir.atom_id_3
_chem_mod_chir.new_volume_sign
F86m1          delete         P1        O4        O5        O6        .
```