### PR TITLE
add ignore_unknown_links to prepare_topology/initialize_refmac_topology

### DIFF
--- a/include/gemmi/placeh.hpp
+++ b/include/gemmi/placeh.hpp
@@ -369,11 +369,12 @@ enum class HydrogenChange { None, Shift, Remove, ReAdd, ReAddButWater };
 
 inline std::unique_ptr<Topo>
 prepare_topology(Structure& st, MonLib& monlib, size_t model_index,
-                 HydrogenChange h_change, bool reorder, bool raise_errors=false) {
+                 HydrogenChange h_change, bool reorder, bool raise_errors=false,
+                 bool ignore_unknown_links=false) {
   std::unique_ptr<Topo> topo(new Topo);
   if (model_index >= st.models.size())
     fail("no such model index: " + std::to_string(model_index));
-  topo->initialize_refmac_topology(st, st.models[model_index], monlib);
+  topo->initialize_refmac_topology(st, st.models[model_index], monlib, ignore_unknown_links);
 
   bool keep = (h_change == HydrogenChange::None || h_change == HydrogenChange::Shift);
   if (!keep || reorder) {

--- a/include/gemmi/topo.hpp
+++ b/include/gemmi/topo.hpp
@@ -318,7 +318,7 @@ struct Topo {
   // Because of the pointers, don't add or remove residues after this step.
   // Monlib may get modified by addition of extra links from the model.
   void initialize_refmac_topology(const Structure& st, Model& model0,
-                                  MonLib& monlib);
+                                  MonLib& monlib, bool ignore_unknown_links=false);
 
   // This step stores pointers to gemmi::Atom's from model0,
   // so after this step don't add or remove atoms.
@@ -403,7 +403,7 @@ inline void Topo::ChainInfo::add_refmac_builtin_modifications() {
 
 // Model is non-const b/c we store non-const pointers to residues in Topo.
 inline void Topo::initialize_refmac_topology(const Structure& st, Model& model0,
-                                             MonLib& monlib) {
+                                             MonLib& monlib, bool ignore_unknown_links) {
   // initialize chains and residues
   for (Chain& chain : model0.chains)
     for (ResidueSpan& sub : chain.subchains()) {
@@ -465,6 +465,9 @@ inline void Topo::initialize_refmac_topology(const Structure& st, Model& model0,
         std::swap(extra.alt1, extra.alt2);
       }
     }
+
+    if (!match && ignore_unknown_links)
+      continue;
 
     if (match) {
       extra.link_id = match->id;

--- a/python/topo.cpp
+++ b/python/topo.cpp
@@ -137,5 +137,6 @@ void add_topo(py::module& m) {
   m.def("prepare_topology", &prepare_topology,
         py::arg("st"), py::arg("monlib"), py::arg("model_index")=0,
         py::arg("h_change")=HydrogenChange::None, py::arg("reorder")=false,
-        py::arg("raise_errors")=false);
+        py::arg("raise_errors")=false,
+        py::arg("ignore_unknown_links")=false);
 }


### PR DESCRIPTION
Topo::initialize_refmac_topology adds bonds to monomer library if the link is not defined. This PR is to make it optional.