### PR TITLE
monlib: read nucleus distances in modifications

### DIFF
--- a/include/gemmi/monlib.hpp
+++ b/include/gemmi/monlib.hpp
@@ -282,11 +282,13 @@ inline Restraints read_restraint_modifications(const cif::Block& block_) {
   for (auto row : block.find("_chem_mod_bond.",
                              {"function", "atom_id_1", "atom_id_2",
                               "new_type",
-                              "new_value_dist", "new_value_dist_esd"}))
+                              "new_value_dist", "new_value_dist_esd",
+                              "?new_value_dist_nucleus", "?new_value_dist_nucleus_esd"}))
     rt.bonds.push_back({{chem_mod_type(row[0]), row.str(1)}, {1, row.str(2)},
                         bond_type_from_string(row[3]), false,
                         cif::as_number(row[4]), cif::as_number(row[5]),
-                        NAN, NAN});
+                        row.has(6) ? cif::as_number(row[6]) : NAN,
+                        row.has(7) ? cif::as_number(row[7]) : NAN});
   for (auto row : block.find("_chem_mod_angle.",
                              {"function", "atom_id_1",
                               "atom_id_2", "atom_id_3",
@@ -433,6 +435,10 @@ inline void ChemMod::apply_to(ChemComp& chemcomp) const {
             it->value = mod.value;
           if (!std::isnan(mod.esd))
             it->esd = mod.esd;
+          if (!std::isnan(mod.value_nucleus))
+            it->value_nucleus = mod.value_nucleus;
+          if (!std::isnan(mod.esd_nucleus))
+            it->esd_nucleus = mod.esd_nucleus;
         }
         break;
     }


### PR DESCRIPTION
New monomer library (in bzr, not yet in ccp4) includes nucleus distances for modifications.