### PR TITLE
add ketopyranose to ResidueInfo and ChemLink::Group

### DIFF
--- a/include/gemmi/monlib.hpp
+++ b/include/gemmi/monlib.hpp
@@ -32,9 +32,9 @@ inline void add_distinct_altlocs(const Residue& res, std::string& altlocs) {
 struct ChemLink {
   enum class Group {
     // _chem_link.group_comp_N is one of:
-    // "peptide", "P-peptide", "M-peptide", "pyranose", "DNA/RNA" or null
+    // "peptide", "P-peptide", "M-peptide", "pyranose", "ketopyranose", "DNA/RNA" or null
     // (we ignore "polymer")
-    Peptide, PPeptide, MPeptide, Pyranose, DnaRna, Null
+    Peptide, PPeptide, MPeptide, Pyranose, Ketopyranose, DnaRna, Null
   };
   struct Side {
     std::string comp;
@@ -68,6 +68,7 @@ struct ChemLink {
         case ialpha4_id("p-pe"): return Group::PPeptide;
         case ialpha4_id("m-pe"): return Group::MPeptide;
         case ialpha4_id("pyra"): return Group::Pyranose;
+        case ialpha4_id("keto"): return Group::Ketopyranose;
         case ialpha4_id("dna/"): return Group::DnaRna;
       }
     }
@@ -80,6 +81,7 @@ struct ChemLink {
       case Group::PPeptide: return "P-peptide";
       case Group::MPeptide: return "M-peptide";
       case Group::Pyranose: return "pyranose";
+      case Group::Ketopyranose: return "ketopyranose";
       case Group::DnaRna: return "DNA/RNA";
       case Group::Null: return ".";
     }
@@ -98,6 +100,7 @@ struct ChemLink {
       case ResidueInfo::BUF:     return Group::Null;
       case ResidueInfo::HOH:     return Group::Null;
       case ResidueInfo::PYR:     return Group::Pyranose;
+      case ResidueInfo::KET:     return Group::Ketopyranose;
       case ResidueInfo::ELS:     return Group::Null;
     }
     unreachable();
@@ -229,6 +232,7 @@ inline ResidueInfo::Kind chemcomp_group_to_kind(const std::string& group) {
       case ialpha4_id("dna"): return ResidueInfo::DNA;
       case ialpha4_id("rna"): return ResidueInfo::RNA;
       case ialpha4_id("pyra"): return ResidueInfo::PYR;
+      case ialpha4_id("keto"): return ResidueInfo::KET;
     }
   }
   return ResidueInfo::UNKNOWN;

--- a/include/gemmi/resinfo.hpp
+++ b/include/gemmi/resinfo.hpp
@@ -19,11 +19,12 @@ struct ResidueInfo {
   // RNA, DNA - nucleic acids
   // HOH - water or heavy water
   // PYR - pyranose according to the refmac dictionary
+  // KET - ketopyranose according to the refmac dictionary
   // BUF - agent from crystallization buffer according to PISA agents.dat
   // ELS - something else (ligand).
   enum Kind : unsigned char {
     // when changing this list update check_polymer_type()
-    UNKNOWN=0, AA, AAD, PAA, MAA, RNA, DNA, BUF, HOH, PYR, ELS
+    UNKNOWN=0, AA, AAD, PAA, MAA, RNA, DNA, BUF, HOH, PYR, KET, ELS
   };
   Kind kind;
   // one-letter code or space (uppercase iff it is a standard residues)

--- a/python/elem.cpp
+++ b/python/elem.cpp
@@ -114,6 +114,7 @@ void add_elem(py::module& m) {
     .value("BUF", ResidueInfo::Kind::BUF)
     .value("HOH", ResidueInfo::Kind::HOH)
     .value("PYR", ResidueInfo::Kind::PYR)
+    .value("KET", ResidueInfo::Kind::KET)
     .value("ELS", ResidueInfo::Kind::ELS);
 
   py::class_<ResidueInfo>(m, "ResidueInfo")

--- a/python/monlib.cpp
+++ b/python/monlib.cpp
@@ -44,6 +44,7 @@ void add_monlib(py::module& m) {
       .value("PPeptide", ChemLink::Group::PPeptide)
       .value("MPeptide", ChemLink::Group::MPeptide)
       .value("Pyranose", ChemLink::Group::Pyranose)
+      .value("Ketopyranose", ChemLink::Group::Ketopyranose)
       .value("DnaRna",   ChemLink::Group::DnaRna)
       .value("Null",     ChemLink::Group::Null);
 


### PR DESCRIPTION
Now monomer library has ketopyranose group, and gemmi could not identify e.g. ALPHA2-3 link as seen in SIA-GAL of 6xtg.