### PR TITLE
xds2mtz: New option --batchmin to delete batches with BATCH<BATCHMIN Default 1.

### DIFF
--- a/include/gemmi/xds_ascii.hpp
+++ b/include/gemmi/xds_ascii.hpp
@@ -37,8 +37,8 @@ struct GEMMI_DLL XdsAscii {
     double maxc;
     int iset = 1;
 
-    // I think ZD can't be negative
-    int frame() const { return int(zd + 1); }
+    // ZD can be negative for a few reflections
+    int frame() const { return std::floor(zd + 1); }
   };
   struct Iset {
     int id;
@@ -184,6 +184,12 @@ struct GEMMI_DLL XdsAscii {
   /// \par overload is maximally allowed pixel value in a peak (MAXC).
   void eliminate_overloads(double overload) {
     vector_remove_if(data, [&](Refl& r) { return r.maxc > overload; });
+  }
+
+  /// \par batchmin lowest allowed batch number.
+  void eliminate_batchmin(double batchmin) {
+      int minz = std::floor(batchmin) - 1;
+      vector_remove_if(data, [&](Refl& r) { return std::floor(r.zd) < minz; });
   }
 };
 


### PR DESCRIPTION
Hi Marcin, please pull this branch. It adds a new option to xds2mtz:

  --batchmin=BATCHMIN      Delete reflections with BATCH<BATCHMIN (default: 1)

It sometimes happens that a few reflections have a negative Z-value. This gives rise to BATCHES with a value of zero or lower. 
Downstream programs can have problems with this.

By default pointless does the same.

Regards,
ClAuS