### PR TITLE
Give the `Assembly` class a nicer string representation

### DIFF
--- a/python/meta.cpp
+++ b/python/meta.cpp
@@ -266,6 +266,9 @@ void add_meta(py::module& m) {
     .def_readwrite("oligomeric_details", &Assembly::oligomeric_details)
     .def_readonly("generators", &Assembly::generators)
     .def_readwrite("special_kind", &Assembly::special_kind)
+    .def("__repr__", [](const Assembly& self) {
+        return cat("<gemmi.Assembly ", self.name, ">");
+    });
     ;
   py::bind_vector<std::vector<Assembly>>(m, "AssemblyList");
 


### PR DESCRIPTION
This is a very small change, but I found that it made it easier to keep track of what was going on in my scripts, so I thought I'd be worth contributing back.