### PR TITLE
Add Custom Boolean Check for Model Objects

### DIFF
--- a/python/mol.cpp
+++ b/python/mol.cpp
@@ -137,6 +137,7 @@ void add_mol(py::module& m) {
     .def("__delitem__", &remove_children<Structure>)
     .def("__delitem__", &Structure::remove_model, py::arg("name"))
     .def("__setitem__", &set_child<Structure, Model>)
+    .def("__bool__", [](Structure& self) {return !self.children().empty();})
     .def("find_connection_by_cra", [](Structure& st, CRA cra1, CRA cra2, bool ignore_segment) {
         return st.find_connection_by_cra(cra1, cra2, ignore_segment);
     }, py::arg("cra1"), py::arg("cra2"), py::arg("ignore_segment")=false,
@@ -255,6 +256,7 @@ void add_mol(py::module& m) {
     .def("__delitem__", &Model::remove_chain, py::arg("name"))
     .def("__delitem__", remove_child<Model>, py::arg("index"))
     .def("__delitem__", remove_children<Model>)
+    .def("__bool__", [](Model& self) {return !self.children().empty();})
     .def("remove_alternative_conformations", remove_alternative_conformations<Model>)
     .def("remove_hydrogens", remove_hydrogens<Model>)
     .def("remove_waters", remove_waters<Model>)
@@ -314,6 +316,7 @@ void add_mol(py::module& m) {
     }, py::return_value_policy::reference_internal)
     .def("__delitem__", remove_child<Chain>, py::arg("index"))
     .def("__delitem__", remove_children<Chain>)
+    .def("__bool__", [](Chain& self) {return !self.children().empty();})
     .def("add_residue", add_child<Chain, Residue>,
          py::arg("residue"), py::arg("pos")=-1,
          py::return_value_policy::reference_internal)
@@ -457,6 +460,7 @@ void add_mol(py::module& m) {
          py::arg("name"), py::return_value_policy::reference_internal)
     .def("__delitem__", remove_child<Residue>, py::arg("index"))
     .def("__delitem__", remove_children<Residue>)
+    .def("__bool__", [](Residue& self) {return !self.children().empty();})
     .def("find_atom", [](Residue& self, const std::string& name, char altloc, Element el) {
            return self.find_atom(name, altloc, el);
          }, py::arg("name"), py::arg("altloc"), py::arg("el")=Element(El::X),

--- a/tests/test_bool.py
+++ b/tests/test_bool.py
@@ -1,5 +1,6 @@
-import gemmi 
 import unittest
+import gemmi 
+
 
 class TestBool(unittest.TestCase):
 

--- a/tests/test_bool.py
+++ b/tests/test_bool.py
@@ -1,0 +1,50 @@
+import gemmi 
+import unittest
+
+class TestBool(unittest.TestCase):
+
+    def test_all(self):
+        s = gemmi.read_structure("5wkd.pdb")
+
+        for m in s:
+            self.assertTrue(m, "Model is empty") 
+            for c in m: 
+                self.assertTrue(c, "Chain is empty") 
+                for r in c:
+                    self.assertTrue(r, "Residue is empty") 
+
+
+    def test_structure(self):
+        s = gemmi.read_structure("5wkd.pdb")
+        self.assertTrue(s, "Structure is empty") 
+        self.assertTrue(s[0], "Model is empty") 
+        self.assertTrue(s[0][0], "Chain is empty") 
+
+        s.add_model(gemmi.Model("A"))
+        self.assertFalse(s[-1], "Model is not empty")
+    
+    def test_model(self):
+        m = gemmi.Model("A")
+        self.assertFalse(m, "Model is not empty")
+        m.add_chain(gemmi.Chain("A"))
+        self.assertTrue(m, "Model is empty")
+        del m[0]
+        self.assertFalse(m, "Model is not empty")
+
+    def test_chain(self):
+        c = gemmi.Chain("A")
+        self.assertFalse(c, "Chain is not empty")
+        c.add_residue(gemmi.Residue())
+        self.assertTrue(c, "Chain is empty")
+        del c[0]
+        self.assertFalse(c, "Chain is not empty")
+
+    def test_residue(self):
+        r = gemmi.Residue()
+        self.assertFalse(r, "Residue is not empty")
+        r.add_atom(gemmi.Atom())
+        self.assertTrue(r, "Residue is empty")
+        del r[0]
+        self.assertFalse(r, "Residue is not empty")
+
+


### PR DESCRIPTION
# Description

This PR adds `__bool__` methods to the Structure, Model, Chain and Residue Python objects. The object will be truthy if it contains any child objects, and falsey if not. An empty container should be rarely encountered in normal use, but when using gemmi for model building, these conditions can arise. 

For example: 
```
structure = gemmi.read_structure("abcd.pdb")

if structure: 
    do_work()
```

This PR also adds a test file for these boolean comparisons in `test_bool.py`. After these changes, all gemmi tests in the tests folder pass.