### PR TITLE
[Feat] Ability to interpolate an array of coordinates

### DIFF
--- a/docs/grid.rst
+++ b/docs/grid.rst
@@ -170,7 +170,7 @@ Similarly in Python:
 .. doctest::
 
   >>> grid.spacegroup = gemmi.find_spacegroup_by_name('P2')
-  
+
 Now let us use one of the symmetrizing functions:
 
 .. doctest::
@@ -439,6 +439,17 @@ to positions in the grid:
 
 (If your points are not on a regular grid -- get in touch -- there might be
 another way.)
+
+Alternatively, if you have an array of positions, you can use the function
+`interpolate_coordinate_array()`. This takes a NumPy array of 3D positions
+and returns a NumPy array of interpolated values.
+
+.. doctest::
+  :skipif: numpy is None
+
+  >>> coords = numpy.array([[1, 2, 3], [2, 3, 4]], dtype=numpy.float32)
+  >>> grid.interpolate_coordinate_array(coords)
+  array([2.0333264, 2.6075664])
 
 .. _masked_grid:
 

--- a/python/grid.cpp
+++ b/python/grid.cpp
@@ -187,7 +187,7 @@ void add_grid_interpolation(py::class_<Grid<T>, GridBase<T>>& grid) {
         auto coords_unchecked = coords.template mutable_unchecked<2>();
         py::array_t<T> result(coords.shape(0));
         auto result_unchecked = result.template mutable_unchecked<1>();
-        for (ssize_t i = 0; i < coords_unchecked.shape(0); ++i) {
+        for (int i = 0; i < coords_unchecked.shape(0); ++i) {
           double x = coords_unchecked(i, 0);
           double y = coords_unchecked(i, 1);
           double z = coords_unchecked(i, 2);

--- a/python/grid.cpp
+++ b/python/grid.cpp
@@ -183,8 +183,8 @@ void add_grid_interpolation(py::class_<Grid<T>, GridBase<T>>& grid) {
          (std::array<double,4> (Gr::*)(const Fractional&) const)
          &Gr::tricubic_interpolation_der)
     .def("interpolate_coordinate_array",
-         [](const Gr& self, py::array_t<double> coords) {
-        auto coords_unchecked = coords.template unchecked<2>();
+         [](const Gr& self, py::array_t<T> coords) {
+        auto coords_unchecked = coords.template mutable_unchecked<2>();
         py::array_t<T> result(coords.shape(0));
         auto result_unchecked = result.template mutable_unchecked<1>();
         for (ssize_t i = 0; i < coords_unchecked.shape(0); ++i) {
@@ -196,7 +196,7 @@ void add_grid_interpolation(py::class_<Grid<T>, GridBase<T>>& grid) {
           result_unchecked(i) = self.interpolate_value(fpos);
         }
         return result;
-    }, py::arg("coords"))
+    }, py::arg().noconvert())
     ;
 }
 

--- a/python/grid.cpp
+++ b/python/grid.cpp
@@ -182,6 +182,21 @@ void add_grid_interpolation(py::class_<Grid<T>, GridBase<T>>& grid) {
     .def("tricubic_interpolation_der",
          (std::array<double,4> (Gr::*)(const Fractional&) const)
          &Gr::tricubic_interpolation_der)
+    .def("interpolate_coordinate_array",
+         [](const Gr& self, py::array_t<double> coords) {
+        auto coords_unchecked = coords.template unchecked<2>();
+        py::array_t<T> result(coords.shape(0));
+        auto result_unchecked = result.template mutable_unchecked<1>();
+        for (ssize_t i = 0; i < coords_unchecked.shape(0); ++i) {
+          double x = coords_unchecked(i, 0);
+          double y = coords_unchecked(i, 1);
+          double z = coords_unchecked(i, 2);
+          Position pos(x, y, z);
+          Fractional fpos = self.unit_cell.fractionalize(pos);
+          result_unchecked(i) = self.interpolate_value(fpos);
+        }
+        return result;
+    }, py::arg("coords"))
     ;
 }
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -43,11 +43,12 @@ class TestFloatGrid(unittest.TestCase):
         self.assertAlmostEqual(m.grid.interpolate_value(frac), pos_value)
 
         # test interpolation on a coordinate array
-        coords = [(19.4, 3., 21.), (19.4, 3., 21.1), (19.4, 3., 21.2)]
-        interp_values = m.grid.interpolate_values(coords)
-        self.assertEqual(len(interp_values), 3)
-        for value in interp_values:
-            self.assertAlmostEqual(value, pos_value)
+        if numpy:
+            coords = [(19.4, 3., 21.), (19.4, 3., 21.1), (19.4, 3., 21.2)]
+            interp_values = m.grid.interpolate_coordinate_array(coords)
+            self.assertEqual(len(interp_values), 3)
+            for value in interp_values:
+                self.assertAlmostEqual(value, pos_value)
 
         # this spacegroup has symop -x, y+1/2, -z
         m.grid.set_value(60 - 3, 24 // 2 + 4, 60 - 5,


### PR DESCRIPTION
## Related Issue

#323 

## Summary

`Ccp4Map.grid.interpolate_values` expects the points to be organized on a regular grid. We often want to interpolate a numpy array of 3D coordinates and return the value at each point. I've added an example of what we would like to see added as an API, as well as testing and some documentation. I'm open to any ideas and I am definitely not settled on the naming of this function - the naming will become quite confusing as is... 

## Example Usage

```python
import timeit
import gemmi
import numpy as np

dmap = gemmi.read_ccp4_map('map.mrc')
grid_arr = dmap.grid.array

coords = np.array([
    [138.462, 128.261, 122.029],
    [139.255, 127.177, 121.461],
    [138.643, 126.674, 120.158],
    [139.349, 126.461, 119.172],
    [139.386, 126.027, 122.46],
    [140.307, 126.324, 123.632],
    [140.408, 125.133, 124.571],
    [141.103, 124.009, 123.954],
    [141.374, 122.867, 124.571],
    [141.022, 122.659, 125.829]
], np.float32)

def gemmi_interp_value():
    return [dmap.grid.interpolate_value(gemmi.Position(*coord)) for coord in coords]

def gemmi_interp_coordinate_array():
    return dmap.grid.interpolate_coordinate_array(coords)

print('** Mean Interpolation Comparison **')
python_loop = gemmi_interp_value()
c_loop = gemmi_interp_coordinate_array()
print('gemmi_interp_value mean:', np.mean(python_loop)) 
print('interpolate_coordinate_array mean:', np.mean(c_loop))

print('\n** Speed Comparison **')
print(f'gemmi_interp_value: {timeit.timeit(gemmi_interp_value, number=100000):.3f} s')
print(f'gemmi_interp_coordinate_array: {timeit.timeit(gemmi_new, number=100000):.3f} s')
```

```
** Mean Interpolation Comparison **
gemmi_interp_value mean: 0.1443351425230503
interpolate_coordinate_array mean: 0.14433515

** Speed Comparison **
gemmi_interp_value: 2.333 s
gemmi_interp_coordinate_array: 0.110 s
```

### Testing

I built gemmi with:

```
python3 -m venv pyenv
source pyenv/bin/activate
python3 -m pip install wheel
python3 -m pip wheel -v .
python3 -m pip install gemmi-*.whl
```

Unit tests are passing with:

`python3 -m unittest discover -v -s tests/`

Docs are building with:

```
python3 -m pip install sphinx
cd docs
sphinx-build -M doctest . _build -n -E
```