### PR TITLE
PyMol saves mmCIF without auth_seq_id, fall back to label_seq_id

### DIFF
--- a/src/mmcif.cpp
+++ b/src/mmcif.cpp
@@ -701,7 +701,7 @@ Structure make_structure_from_block(const cif::Block& block_) {
                                       "occupancy",
                                       "B_iso_or_equiv",
                                       "?pdbx_formal_charge",
-                                      "auth_seq_id",
+                                      "?auth_seq_id",
                                       "?auth_comp_id",
                                       "?auth_asym_id",
                                       "?auth_atom_id",
@@ -715,10 +715,13 @@ Structure make_structure_from_block(const cif::Block& block_) {
     // we use only one comp (residue) and one atom name
     const int kCompId = atom_table.first_of(kAuthCompId, kLabelCompId);
     const int kAtomId = atom_table.first_of(kAuthAtomId, kLabelAtomId);
+    const int kSeqId = atom_table.first_of(kAuthSeqId, kLabelSeqId);
     if (!atom_table.has_column(kCompId))
       fail("Neither _atom_site.label_comp_id nor auth_comp_id found");
     if (!atom_table.has_column(kAtomId))
       fail("Neither _atom_site.label_atom_id nor auth_atom_id found");
+    if (!atom_table.has_column(kSeqId))
+      fail("Neither _atom_site.label_seq_id nor auth_seq_id found");
 
     st.has_d_fraction = atom_table.has_column(kDeuterium);
 
@@ -740,7 +743,7 @@ Structure make_structure_from_block(const cif::Block& block_) {
         resi = nullptr;
       }
       ResidueId rid = make_resid(cif::as_string(row[kCompId]),
-                                 cif::as_string(row[kAuthSeqId]),
+                                 cif::as_string(row[kSeqId]),
                                  row.has(kInsCode) ? &row[kInsCode] : nullptr);
       if (!resi || !resi->matches(rid)) {
         resi = chain->find_or_add_residue(rid);


### PR DESCRIPTION
I found that Foldseek does not extract any chains from PyMol exported mmCIF files. Tracking the issue down to gemmi seems to be due to gemmi requiring `auth_seq_id` to be present, but PyMol not saving it.

I tested the PR within Foldseek and everything works as expected.

I also attached a mmCIF file exported from PyMol that has the issue.

[pymol_wo_auth_seq_id.cif.txt](https://github.com/user-attachments/files/16139475/pymol_wo_auth_seq_id.cif.txt)
