### PR TITLE
Allow wider MODEL field to increase maximum number of models

### DIFF
--- a/src/pdb.cpp
+++ b/src/pdb.cpp
@@ -1155,7 +1155,7 @@ Structure read_pdb_from_stream(LineReaderBase&& line_reader, const std::string& 
     } else if (is_record_type4(line, "MODEL")) {
       if (model && chain)
         wrong("MODEL without ENDMDL?");
-      int num = read_int(line+10, 4);
+      int num = read_int(line+6, 8);
       model = &st.find_or_add_model(num);
       if (!model->chains.empty())
         wrong("duplicate MODEL number: " + std::to_string(num));


### PR DESCRIPTION
Increases the maximum model sequence number to 99999999 (almost 100 million).

The format of a MODEL record in a PDB file is specified as the string "MODEL ", some spaces and a 4-digit serial number. Due to the field width of four, the highest model number can only be 9999.  However, this causes issues for some generated PDB files, such as converted MD trajetories with more than 9999 frames.

This change "extends" the PDB format [specification](https://www.wwpdb.org/documentation/file-format-content/format33/sect9.html). This should be safe because previous behaviour is preserved for model numbers <= 9999 and only uses the space currently occupied by spaces between the MODEL string and the model sequence number.