### PR TITLE
pdb input helper functions for populating Structure based classes

### DIFF
--- a/include/gemmi/pdb.hpp
+++ b/include/gemmi/pdb.hpp
@@ -31,9 +31,33 @@ inline bool is_record_type3(const char* s, const char* record) {
 /// Returns operations corresponding to 1555, 2555, ... N555
 GEMMI_DLL std::vector<Op> read_remark_290(const std::vector<std::string>& raw_remarks);
 
-GEMMI_DLL Structure read_pdb_from_stream(AnyStream& line_reader,
-                                         const std::string& source,
-                                         PdbReadOptions options);
+GEMMI_DLL void populate_structure_from_pdb_stream(AnyStream& line_reader,
+                                                  const std::string& source,
+                                                  Structure& st,
+                                                  PdbReadOptions options);
+
+inline void populate_structure_from_pdb_memory(const char* data, size_t size,
+                                               const std::string& name,
+                                               Structure& st,
+                                               PdbReadOptions options={}) {
+  MemoryStream stream{data, size};
+  populate_structure_from_pdb_stream(stream, name, st, options);
+}
+
+inline void populate_structure_from_pdb_string(const std::string& str,
+                                              const std::string& name,
+                                              Structure& st,
+                                              PdbReadOptions options={}) {
+  populate_structure_from_pdb_memory(str.c_str(), str.length(), name, st, options);
+}
+
+inline Structure read_pdb_from_stream(AnyStream& line_reader,
+                                      const std::string& source,
+                                      PdbReadOptions options) {
+  gemmi::Structure st;
+  populate_structure_from_pdb_stream(line_reader, source, st, options);
+  return st;
+};
 
 inline Structure read_pdb_file(const std::string& path,
                                PdbReadOptions options={}) {

--- a/python/read.cpp
+++ b/python/read.cpp
@@ -99,6 +99,8 @@ void add_read_structure(nb::module_& m) {
         nb::arg("block"), nb::arg("which")=7,
         "CIF block from CCD or monomer library -> single-residue Model(s).");
 
+  m.def("populate_structure_from_pdb_stream", &populate_structure_from_pdb_stream,
+        nb::arg("line_reader"), nb::arg("source"), nb::arg("st"), nb::arg("options"));
   m.def("read_pdb_string", [](const std::string& s, int max_line_length,
                               bool ignore_ter, bool split_chain_on_ter) {
           PdbReadOptions options{max_line_length, ignore_ter, split_chain_on_ter, false};

--- a/src/pdb.cpp
+++ b/src/pdb.cpp
@@ -857,11 +857,11 @@ void read_metadata_from_remarks(Structure& st) {
 
 } // anonymous namespace
 
-Structure read_pdb_from_stream(AnyStream& line_reader, const std::string& source,
-                               PdbReadOptions options) {
+void populate_structure_from_pdb_stream(AnyStream& line_reader, const std::string& source,
+                                        Structure& st,
+                                        PdbReadOptions options) {
   if (options.max_line_length <= 0 || options.max_line_length > 120)
     options.max_line_length = 120;
-  Structure st;
   st.input_format = CoorFormat::Pdb;
   st.name = path_basename(source, {".gz", ".pdb"});
   Transform matrix;
@@ -1236,7 +1236,6 @@ Structure read_pdb_from_stream(AnyStream& line_reader, const std::string& source
     read_metadata_from_remarks(st);
 
   restore_full_ccd_codes(st);
-  return st;
 }
 
 std::vector<Op> read_remark_290(const std::vector<std::string>& raw_remarks) {


### PR DESCRIPTION
Hi @wojdyr,
Please check if I followed your pattern for these pdb helper functions for populating Structure based classes.

I didn't add any test cases but could if that would be a part of PR's.

The python compiles though I haven't tried from the python layer.

My c++ usage works great