### PR TITLE
docs: full Doxygen API documentation for structure I/O

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,66 @@
+.. _api:
+
+C++ API Reference
+#################
+
+This page documents the Gemmi C++ library API, generated from Doxygen comments
+in ``include/gemmi/*.hpp``. It is updated with each pull request in the
+API documentation series.
+
+For the Python API, see the `Python API reference <https://project-gemmi.github.io/python-api/>`_.
+
+.. note::
+
+   Documentation coverage is being added incrementally. Headers not yet
+   listed here will appear in subsequent pull requests.
+
+Core Data Structures
+--------------------
+
+*(Full documentation added in PR 2.)*
+
+.. doxygenfile:: model.hpp
+   :project: gemmi
+
+Structure I/O
+-------------
+
+*(Full documentation added in PR 4.)*
+
+.. doxygenfile:: mmcif.hpp
+   :project: gemmi
+
+.. doxygenfile:: mmread.hpp
+   :project: gemmi
+
+.. doxygenfile:: mmread_gz.hpp
+   :project: gemmi
+
+.. doxygenfile:: pdb.hpp
+   :project: gemmi
+
+.. doxygenfile:: to_mmcif.hpp
+   :project: gemmi
+
+.. doxygenfile:: to_pdb.hpp
+   :project: gemmi
+
+.. doxygenfile:: crd.hpp
+   :project: gemmi
+
+.. doxygenfile:: smcif.hpp
+   :project: gemmi
+
+.. doxygenfile:: mmdb.hpp
+   :project: gemmi
+
+.. doxygenfile:: pirfasta.hpp
+   :project: gemmi
+
+Map and Grid Data
+-----------------
+
+*(Stub — full documentation added in PR 6.)*
+
+.. doxygenfile:: grid.hpp
+   :project: gemmi

--- a/include/gemmi/crd.hpp
+++ b/include/gemmi/crd.hpp
@@ -22,7 +22,7 @@ namespace gemmi {
 /// - Deduplicates and validates entity definitions.
 ///
 /// @param st The Structure to prepare (modified in-place).
-void setup_for_crd(Structure& st);
+GEMMI_DLL void setup_for_crd(Structure& st);
 
 /// @brief Identify and add missing chemical bonds using a monomer library.
 ///
@@ -33,7 +33,7 @@ void setup_for_crd(Structure& st);
 /// @param model The Model containing atoms to search.
 /// @param st The Structure whose connections will be updated.
 /// @param monlib The MonLib (monomer library) for matching link definitions.
-void add_automatic_links(Model& model, Structure& st, const MonLib& monlib);
+GEMMI_DLL void add_automatic_links(Model& model, Structure& st, const MonLib& monlib);
 
 /// @brief Add chemical component dictionary blocks to a CIF document.
 ///
@@ -45,7 +45,7 @@ void add_automatic_links(Model& model, Structure& st, const MonLib& monlib);
 /// @param resnames List of residue names (component IDs) to include.
 /// @param topo The Topo containing topology information.
 /// @param monlib The MonLib containing chemical component definitions.
-void add_dictionary_blocks(cif::Document& doc, const std::vector<std::string>& resnames,
+GEMMI_DLL void add_dictionary_blocks(cif::Document& doc, const std::vector<std::string>& resnames,
                                      const Topo& topo, const MonLib& monlib);
 
 /// @brief Generate a complete Refmac CRD (coordinate) file as a CIF document.

--- a/include/gemmi/crd.hpp
+++ b/include/gemmi/crd.hpp
@@ -2,6 +2,9 @@
 //
 // Generate Refmac intermediate (prepared) files crd and rst
 
+/// @file
+/// @brief Preparation of molecular structures for Refmac refinement (CRD format generation).
+
 #ifndef GEMMI_CRD_HPP_
 #define GEMMI_CRD_HPP_
 
@@ -9,14 +12,60 @@
 
 namespace gemmi {
 
-GEMMI_DLL void setup_for_crd(Structure& st);
+/// @brief Prepare a Structure for CRD file output.
+///
+/// Sets up entities, assigns subchains, and ensures proper formatting for Refmac input:
+/// - Adds entity type and ID information.
+/// - Forces subchain assignment.
+/// - Adjusts subchain names to Refmac conventions (using '_' as separator).
+/// - Normalizes all water residues to "HOH".
+/// - Deduplicates and validates entity definitions.
+///
+/// @param st The Structure to prepare (modified in-place).
+void setup_for_crd(Structure& st);
 
-GEMMI_DLL void add_automatic_links(Model& model, Structure& st, const MonLib& monlib);
+/// @brief Identify and add missing chemical bonds using a monomer library.
+///
+/// Searches for atoms within bonding distance and, when not already defined
+/// as connections in the structure, attempts to match them against the monomer
+/// library. Automatically adds Connection records for metals coordinated to O, N, S, B.
+///
+/// @param model The Model containing atoms to search.
+/// @param st The Structure whose connections will be updated.
+/// @param monlib The MonLib (monomer library) for matching link definitions.
+void add_automatic_links(Model& model, Structure& st, const MonLib& monlib);
 
-GEMMI_DLL void add_dictionary_blocks(cif::Document& doc, const std::vector<std::string>& resnames,
+/// @brief Add chemical component dictionary blocks to a CIF document.
+///
+/// Appends _chem_comp blocks for specified residue types extracted from
+/// the topology and monomer library. Used to embed component definitions
+/// in Refmac CRD files.
+///
+/// @param doc The cif::Document to append blocks to.
+/// @param resnames List of residue names (component IDs) to include.
+/// @param topo The Topo containing topology information.
+/// @param monlib The MonLib containing chemical component definitions.
+void add_dictionary_blocks(cif::Document& doc, const std::vector<std::string>& resnames,
                                      const Topo& topo, const MonLib& monlib);
 
-// Structure is not const b/c this function calls shorten_ccd_codes(st)
+/// @brief Generate a complete Refmac CRD (coordinate) file as a CIF document.
+///
+/// Creates a comprehensive CIF document suitable for Refmac input, including:
+/// - Structure metadata (entry ID, cell, space group, symmetry).
+/// - Entity and sequence definitions.
+/// - Atomic coordinates with topology-derived labels.
+/// - NCS operations, structural connectivity, cis-peptides.
+/// - Optional anisotropic displacement parameters.
+/// - Hydrogen handling flags based on h_change parameter.
+///
+/// The Structure is modified: shorten_ccd_codes() is called to abbreviate
+/// component IDs for Refmac compatibility.
+///
+/// @param st The Structure to serialize (modified: CCD codes shortened).
+/// @param topo The Topo with topology and restraint information.
+/// @param monlib The MonLib for component definitions and link types.
+/// @param h_change How to handle hydrogen atoms (remove, shift, or keep).
+/// @return A cif::Document containing the prepared CRD file structure.
 GEMMI_DLL cif::Document prepare_refmac_crd(Structure& st, const Topo& topo,
                                            const MonLib& monlib, HydrogenChange h_change);
 

--- a/include/gemmi/mmcif.hpp
+++ b/include/gemmi/mmcif.hpp
@@ -1,3 +1,6 @@
+/// @file
+/// @brief Read mmCIF (PDBx/mmCIF) coordinate files into a Structure.
+
 // Copyright 2017 Global Phasing Ltd.
 //
 // Read mmCIF (PDBx/mmCIF) file into a Structure from model.hpp.
@@ -12,16 +15,31 @@
 
 namespace gemmi {
 
-/// structure from a coordinate mmCIF block
+/// Populate Structure by parsing a coordinate mmCIF block.
+/// @param block_ A CIF block containing the coordinate data (typically from
+///               an mmCIF file, containing _atom_site categories)
+/// @param st     The Structure to populate with coordinates, cell parameters,
+///               and other crystallographic data
+/// @throws Throws on parse errors or invalid coordinate data
 GEMMI_DLL void populate_structure_from_block(const cif::Block& block_, Structure& st);
 
+/// Build a Structure by parsing a coordinate mmCIF block.
+/// Convenience wrapper around populate_structure_from_block().
+/// @param block_ A CIF block containing the coordinate data
+/// @return A new Structure populated from the block
 inline Structure make_structure_from_block(const cif::Block& block_) {
   gemmi::Structure st;
   populate_structure_from_block(block_, st);
   return st;
 }
 
-/// structure from a coordinate mmCIF document
+/// Build a Structure from a parsed mmCIF document.
+/// Parses the first block (coordinate block) and validates that only
+/// the first block contains atomic coordinates.
+/// @param doc      A CIF document (typically mmCIF); moved into this function
+/// @param save_doc Optional pointer to receive a copy of the parsed document
+/// @return A Structure populated from the first block of the document
+/// @throws Throws if multiple blocks contain atomic coordinates (_atom_site)
 inline Structure make_structure(cif::Document&& doc, cif::Document* save_doc=nullptr) {
   // mmCIF files for deposition may have more than one block:
   // coordinates in the first block and restraints in the others.
@@ -35,19 +53,31 @@ inline Structure make_structure(cif::Document&& doc, cif::Document* save_doc=nul
   return st;
 }
 
-// Reading chemical component as a coordinate file.
+/// @brief Selects which coordinate model(s) to read from chemical component files.
+/// Used when reading CCD (Chemical Component Dictionary) or monomer library entries.
 enum class ChemCompModel {
-  Xyz      = 1, // _chem_comp_atom.x, etc
-  Example  = 2, // _chem_comp_atom.model_Cartn_x
-  Ideal    = 4, // _chem_comp_atom.pdbx_model_Cartn_x_ideal
-  First    = 8  // whatever comes first in the input file
+  Xyz      = 1, ///< Cartesian coordinates from _chem_comp_atom.x/y/z fields
+  Example  = 2, ///< Example model coordinates from _chem_comp_atom.model_Cartn_x/y/z
+  Ideal    = 4, ///< Ideal coordinates from _chem_comp_atom.pdbx_model_Cartn_x/y/z_ideal
+  First    = 8  ///< Whichever coordinate set appears first in the input file
 };
 
+/// Bitwise OR operator for ChemCompModel flags.
 constexpr int operator|(ChemCompModel a, ChemCompModel b) { return (int)a | (int)b; }
 
-/// make_residue_from_chemcomp_block
+/// Extract a Residue from a chemical component block.
+/// Reads atom coordinates and bond information from a CCD or monomer library block.
+/// @param block The CIF block containing chemical component data
+/// @param kind  Which coordinate model to extract (Xyz, Example, Ideal, or First)
+/// @return A Residue with atoms positioned according to the selected model
 GEMMI_DLL Residue make_residue_from_chemcomp_block(const cif::Block& block, ChemCompModel kind);
 
+/// Build a single-residue Model from a chemical component block.
+/// Convenience wrapper that creates a Model with an unnamed chain
+/// containing a single Residue extracted from the block.
+/// @param block The CIF block containing chemical component data
+/// @param kind  Which coordinate model to extract
+/// @return A Model with one empty chain containing one Residue
 inline Model make_model_from_chemcomp_block(const cif::Block& block, ChemCompModel kind) {
   Model model;
   model.chains.emplace_back("");
@@ -55,10 +85,14 @@ inline Model make_model_from_chemcomp_block(const cif::Block& block, ChemCompMod
   return model;
 }
 
-// For CCD input - returns a structure with two single-residue models:
-// example (model_Cartn_x) and ideal (pdbx_model_Cartn_x_ideal).
-// For Refmac dictionary (monomer library) files returns structure with
-// a single model.
+/// Build a Structure from a chemical component block.
+/// For CCD input, generates a structure with multiple single-residue models
+/// (xyz, example, and/or ideal coordinates as requested).
+/// For Refmac monomer library (dictionary) files, generates a single model.
+/// The structure's input_format is set to CoorFormat::ChemComp.
+/// @param block Which CIF block to parse (typically the chemical component block)
+/// @param which Bitmask of ChemCompModel values to include; default 7 = Xyz|Example|Ideal
+/// @return A Structure containing the requested coordinate models
 inline Structure make_structure_from_chemcomp_block(const cif::Block& block, int which=7) {
   Structure st;
   st.input_format = CoorFormat::ChemComp;
@@ -75,10 +109,18 @@ inline Structure make_structure_from_chemcomp_block(const cif::Block& block, int
   return st;
 }
 
-// a helper function for use with make_structure_from_chemcomp_block():
-//   int n = check_chemcomp_block_number(doc);
-//   if (n != -1)
-//     Structure st = make_structure_from_chemcomp_block(doc.blocks[n]);
+/// Identify which block in a document contains chemical component data.
+/// Helper for make_structure_from_chemcomp_block(); distinguishes between
+/// three file formats: monomer library with/without global block, and CCD files.
+/// Example usage:
+/// @code
+/// int n = check_chemcomp_block_number(doc);
+/// if (n != -1)
+///   Structure st = make_structure_from_chemcomp_block(doc.blocks[n]);
+/// @endcode
+/// @param doc A parsed CIF document
+/// @return Block index (0, 1, or 2) if recognized as chemical component file;
+///         -1 if not a recognized chemical component format
 inline int check_chemcomp_block_number(const cif::Document& doc) {
   // monomer library file without global_
   if (doc.blocks.size() == 2 && doc.blocks[0].name == "comp_list")
@@ -96,6 +138,14 @@ inline int check_chemcomp_block_number(const cif::Document& doc) {
   return -1;
 }
 
+/// Build a Structure from a chemical component document.
+/// Automatically detects and parses the appropriate block in a chemical
+/// component file (CCD, monomer library with/without global block).
+/// @param doc      A parsed chemical component CIF document
+/// @param save_doc Optional pointer to receive a copy of the parsed document
+/// @param which    Bitmask of ChemCompModel values to include; default 7 = all
+/// @return A Structure with the requested coordinate models
+/// @throws Throws if the document is not a recognized chemical component format
 inline Structure make_structure_from_chemcomp_doc(const cif::Document& doc,
                                                   cif::Document* save_doc=nullptr,
                                                   int which=7) {

--- a/include/gemmi/mmcif.hpp
+++ b/include/gemmi/mmcif.hpp
@@ -37,7 +37,7 @@ inline Structure make_structure_from_block(const cif::Block& block_) {
 /// Parses the first block (coordinate block) and validates that only
 /// the first block contains atomic coordinates.
 /// @param doc      A CIF document (typically mmCIF); moved into this function
-/// @param save_doc Optional pointer to receive a copy of the parsed document
+/// @param save_doc Optional pointer to receive the parsed document (moved into *save_doc)
 /// @return A Structure populated from the first block of the document
 /// @throws Throws if multiple blocks contain atomic coordinates (_atom_site)
 inline Structure make_structure(cif::Document&& doc, cif::Document* save_doc=nullptr) {
@@ -62,7 +62,6 @@ enum class ChemCompModel {
   First    = 8  ///< Whichever coordinate set appears first in the input file
 };
 
-/// Bitwise OR operator for ChemCompModel flags.
 constexpr int operator|(ChemCompModel a, ChemCompModel b) { return (int)a | (int)b; }
 
 /// Extract a Residue from a chemical component block.
@@ -142,7 +141,7 @@ inline int check_chemcomp_block_number(const cif::Document& doc) {
 /// Automatically detects and parses the appropriate block in a chemical
 /// component file (CCD, monomer library with/without global block).
 /// @param doc      A parsed chemical component CIF document
-/// @param save_doc Optional pointer to receive a copy of the parsed document
+/// @param save_doc Optional pointer to receive the parsed document (moved into *save_doc)
 /// @param which    Bitmask of ChemCompModel values to include; default 7 = all
 /// @return A Structure with the requested coordinate models
 /// @throws Throws if the document is not a recognized chemical component format

--- a/include/gemmi/mmdb.hpp
+++ b/include/gemmi/mmdb.hpp
@@ -1,6 +1,11 @@
-// Copyright 2020-2022 Global Phasing Ltd.
-//
-// Converts between gemmi::Structure and mmdb::Manager.
+/// @file
+/// @brief Conversion between gemmi::Structure and MMDB (CCP4 Macromolecular Data Bank).
+///
+/// Copyright 2020-2022 Global Phasing Ltd.
+///
+/// Provides bidirectional conversion functions between Gemmi's Structure
+/// representation and MMDB's Manager data structures. This enables
+/// interoperability with CCP4's legacy molecular biology library.
 
 #ifndef GEMMI_MMDB_HPP_
 #define GEMMI_MMDB_HPP_
@@ -14,6 +19,10 @@
 
 namespace gemmi {
 
+/// @brief Copies a Gemmi transformation matrix and vector to MMDB format.
+/// @param tr Gemmi transformation object (3x3 rotation + 3D translation).
+/// @param mat Output MMDB 3x3 matrix (rotation component).
+/// @param vec Output MMDB 3D vector (translation component).
 inline void copy_transform_to_mmdb(const Transform& tr,
                                    mmdb::mat33& mat, mmdb::vect3& vec) {
   for (int i = 0; i < 3; ++i) {
@@ -23,6 +32,11 @@ inline void copy_transform_to_mmdb(const Transform& tr,
   }
 }
 
+/// @brief Safely copies a string into a fixed-size MMDB character array.
+/// @tparam N Size of the destination character array.
+/// @param dest Fixed-size MMDB character array (typically a typedef like mmdb::ChainID).
+/// @param src String to copy.
+/// @throws Throws if src is too long for the destination array.
 template<int N>
 void strcpy_to_mmdb(char (&dest)[N], const std::string& src) {
   if (src.size() + 1 >= N)
@@ -30,6 +44,10 @@ void strcpy_to_mmdb(char (&dest)[N], const std::string& src) {
   std::memcpy(dest, src.c_str(), src.size() + 1);
 }
 
+/// @brief Sets MMDB sequence number and insertion code from Gemmi SeqId.
+/// @param seqnum Pointer to MMDB sequence number (output).
+/// @param icode MMDB insertion code array (output).
+/// @param seqid Gemmi sequence ID containing number and optional insertion code.
 inline void set_seqid_in_mmdb(int* seqnum, mmdb::InsCode& icode, SeqId seqid) {
   *seqnum = *seqid.num;
   icode[0] = icode[1] = '\0';
@@ -37,10 +55,19 @@ inline void set_seqid_in_mmdb(int* seqnum, mmdb::InsCode& icode, SeqId seqid) {
     icode[0] = seqid.icode;
 }
 
+/// @brief Converts MMDB sequence number and insertion code to Gemmi SeqId.
+/// @param seqnum MMDB sequence number.
+/// @param inscode MMDB insertion code array.
+/// @return Gemmi SeqId with number and optional insertion code.
 inline SeqId seqid_from_mmdb(int seqnum, const mmdb::InsCode& inscode) {
   return SeqId(seqnum, inscode[0] ? inscode[0] : ' ');
 }
 
+/// @brief Converts Gemmi CisPep to MMDB CisPep structure.
+/// @param g Gemmi CisPep record to convert.
+/// @param ser_num Serial number for the MMDB record.
+/// @param model_num Model number for the MMDB record.
+/// @return Newly allocated MMDB CisPep (caller owns memory).
 inline mmdb::CisPep* cispep_to_mmdb(const CisPep& g, int ser_num, int model_num) {
   mmdb::CisPep* m = new mmdb::CisPep();
   m->serNum = ser_num;
@@ -55,6 +82,10 @@ inline mmdb::CisPep* cispep_to_mmdb(const CisPep& g, int ser_num, int model_num)
   return m;
 }
 
+/// @brief Converts MMDB CisPep structure to Gemmi CisPep.
+/// @param m MMDB CisPep record to convert.
+/// @param model_num Model number for the result.
+/// @return Gemmi CisPep with data from MMDB record.
 inline CisPep cispep_from_mmdb(const mmdb::CisPep& m, int model_num) {
   CisPep g;
   g.partner_c.res_id.name = m.pep1;
@@ -68,6 +99,12 @@ inline CisPep cispep_from_mmdb(const mmdb::CisPep& m, int model_num) {
   return g;
 }
 
+/// @brief Transfers Connection records from Gemmi Structure to MMDB Manager.
+/// @param st Gemmi Structure containing Connection records.
+/// @param mol MMDB Manager to populate with Link records.
+/// Converts Gemmi Connection objects to MMDB Link format and adds them
+/// to all models in the MMDB Manager. Links with undefined sequence IDs
+/// are skipped.
 inline void transfer_links_to_mmdb(const Structure& st,  mmdb::Manager* mol) {
   // based on code provided by Paul Emsley
   for (const Connection& con : st.connections) {
@@ -101,7 +138,11 @@ inline void transfer_links_to_mmdb(const Structure& st,  mmdb::Manager* mol) {
   }
 }
 
-// ignoring LinkR's here
+/// @brief Transfers Link records from MMDB to Gemmi Structure.
+/// @param mmdb_links MMDB LinkContainer to read from.
+/// @param st Gemmi Structure to populate with Connection records (output).
+/// Converts MMDB Link objects to Gemmi Connection format.
+/// Note: LinkR (restraint) entries are not transferred.
 inline void transfer_links_from_mmdb(mmdb::LinkContainer& mmdb_links, Structure& st) {
   for (int i = 0; i < mmdb_links.Length(); ++i) {
     mmdb::Link& link = *static_cast<mmdb::Link*>(mmdb_links.GetContainerClass(i));
@@ -135,7 +176,11 @@ inline void transfer_links_from_mmdb(mmdb::LinkContainer& mmdb_links, Structure&
   }
 }
 
-// Helper function to convert gemmi sequence to mmdb ResName array
+/// @brief Converts Gemmi sequence vector to MMDB SeqRes format.
+/// @param sequence Gemmi polymer sequence (residue names).
+/// @param seqres MMDB SeqRes structure to populate (output).
+/// Handles microheterogeneity by extracting the first monomer from each
+/// sequence entry. Allocates and manages MMDB internal memory.
 inline void set_mmdb_seqres(const std::vector<std::string>& sequence,
                             mmdb::SeqRes& seqres) {
   // Free existing sequence data
@@ -162,6 +207,9 @@ inline void set_mmdb_seqres(const std::vector<std::string>& sequence,
   }
 }
 
+/// @brief Checks if Structure has polymer entities with defined sequences.
+/// @param st Structure to check.
+/// @return True if at least one polymer entity with sequence data exists.
 inline bool has_sequences(const Structure& st) {
   // If there are no entities with sequences, try to infer sequences from chains
   for (const Entity& entity : st.entities) {
@@ -171,7 +219,11 @@ inline bool has_sequences(const Structure& st) {
   return false;
 }
 
-// Transfer SEQRES from gemmi entities to mmdb chains
+/// @brief Transfers polymer sequence information from Gemmi to MMDB Manager.
+/// @param st Gemmi Structure containing entity sequence data.
+/// @param manager MMDB Manager to populate (output).
+/// Copies full_sequence data from Gemmi entities to corresponding MMDB
+/// chain SEQRES records. Does nothing if Structure has no sequences.
 inline void transfer_seqres_to_mmdb(const Structure& st, mmdb::Manager* manager) {
   if (!has_sequences(st))
     return;
@@ -205,6 +257,12 @@ inline void transfer_seqres_to_mmdb(const Structure& st, mmdb::Manager* manager)
   }
 }
 
+/// @brief Copies Gemmi Structure data into MMDB Manager.
+/// @param st Gemmi Structure to convert.
+/// @param manager MMDB Manager to populate (output).
+/// Transfers all structural information including atoms, residues, chains,
+/// crystallographic metadata (cell, spacegroup, NCS operators), SEQRES records,
+/// and Connection information. Handles TER records to mark polymer termination.
 inline void copy_to_mmdb(const Structure& st, mmdb::Manager* manager) {
   for (const std::string& s : st.raw_remarks) {
     std::string line = rtrim_str(s);
@@ -318,7 +376,11 @@ inline void copy_to_mmdb(const Structure& st, mmdb::Manager* manager) {
 }
 
 
-// don't use const for mmdb objects - MMDB doesn't have const method
+/// @brief Converts MMDB Atom to Gemmi Atom.
+/// @param m_atom MMDB Atom to convert (non-const; MMDB API limitation).
+/// @return Gemmi Atom with data from MMDB record.
+/// Extracts coordinates, occupancy, B-factors, anisotropic temperature factors
+/// (if present), element, charge, and atom name/serial information.
 inline Atom copy_atom_from_mmdb(mmdb::Atom& m_atom) {
   Atom atom;
   atom.name = m_atom.label_atom_id;
@@ -340,6 +402,11 @@ inline Atom copy_atom_from_mmdb(mmdb::Atom& m_atom) {
   return atom;
 }
 
+/// @brief Converts MMDB Residue to Gemmi Residue.
+/// @param m_res MMDB Residue to convert.
+/// @return Gemmi Residue with atoms and metadata.
+/// Extracts all atoms, identifies polymer termination via TER pseudo-atoms,
+/// and sets het_flag and segment information from first atom.
 inline Residue copy_residue_from_mmdb(mmdb::Residue& m_res) {
   Residue res;
   res.name = m_res.name;
@@ -363,7 +430,11 @@ inline Residue copy_residue_from_mmdb(mmdb::Residue& m_res) {
   return res;
 }
 
-// Helper function to convert mmdb ResName array to gemmi sequence
+/// @brief Converts MMDB SeqRes to Gemmi sequence vector.
+/// @param seqres MMDB SeqRes structure to read.
+/// @return Vector of residue names (sequence).
+/// Extracts sequence data from MMDB SeqRes, handling empty entries and
+/// trimming whitespace from each residue name.
 inline std::vector<std::string> get_gemmi_sequence(const mmdb::SeqRes& seqres) {
   std::vector<std::string> sequence;
   if (seqres.numRes > 0 && seqres.resName) {
@@ -378,6 +449,12 @@ inline std::vector<std::string> get_gemmi_sequence(const mmdb::SeqRes& seqres) {
   return sequence;
 }
 
+/// @brief Converts MMDB Chain to Gemmi Chain and updates Structure entities.
+/// @param st Gemmi Structure to update with entity information (output).
+/// @param m_chain MMDB Chain to convert.
+/// @return Gemmi Chain with residues and sequence data.
+/// Extracts chain residues and SEQRES information, creating or updating
+/// corresponding polymer entities in the Structure.
 inline Chain copy_chain_from_mmdb(Structure& st, mmdb::Chain& m_chain) {
   Chain chain(m_chain.GetChainID());
   int n = m_chain.GetNumberOfResidues();
@@ -405,6 +482,12 @@ inline Chain copy_chain_from_mmdb(Structure& st, mmdb::Chain& m_chain) {
   return chain;
 }
 
+/// @brief Converts MMDB Model to Gemmi Model and updates Structure entities.
+/// @param st Gemmi Structure to update with entity information (output).
+/// @param m_model MMDB Model to convert.
+/// @return Gemmi Model with chains.
+/// Extracts all chains and their sequence information, updating entity
+/// records and deduplicating entity data.
 inline Model copy_model_from_mmdb(Structure& st, mmdb::Model& m_model) {
   Model model(m_model.GetSerNum());
   int n = m_model.GetNumberOfChains();
@@ -424,6 +507,11 @@ inline Model copy_model_from_mmdb(Structure& st, mmdb::Model& m_model) {
   return model;
 }
 
+/// @brief Converts MMDB Manager into Gemmi Structure.
+/// @param manager MMDB Manager to convert.
+/// @return Gemmi Structure with all models, atoms, and metadata.
+/// Transfers crystallographic cell parameters, spacegroup information,
+/// all models and chains, CISPEP records, and inter-chain connections.
 inline Structure copy_from_mmdb(mmdb::Manager* manager) {
   Structure st;
   const mmdb::Cryst& cryst = *manager->GetCrystData();

--- a/include/gemmi/mmread.hpp
+++ b/include/gemmi/mmread.hpp
@@ -62,7 +62,8 @@ inline CoorFormat coor_format_from_content(const char* buf, const char* end) {
 /// component file and parses it accordingly; otherwise treats as normal mmCIF.
 /// @param doc                A CIF document; moved into this function
 /// @param possible_chemcomp  If true, check for and handle CCD/monomer library files
-/// @param save_doc           Optional pointer to receive a copy of the document
+/// @param save_doc           Optional pointer to receive the document; only populated if
+///                           the input is mmCIF (not a chemical component)
 /// @return A Structure parsed from the document
 inline Structure make_structure_from_doc(cif::Document&& doc, bool possible_chemcomp,
                                          cif::Document* save_doc=nullptr) {

--- a/include/gemmi/mmread.hpp
+++ b/include/gemmi/mmread.hpp
@@ -116,10 +116,10 @@ inline Structure read_structure_from_char_array(char* data, size_t size,
   return read_structure_from_memory(data, size, path, CoorFormat::Unknown, save_doc);
 }
 
-/// Read a Structure from an input source.
+/// @brief Read a Structure from an input source.
+/// @tparam T       Input type (e.g., BasicInput, FileStream) with path() and create_stream()
 /// Generic template that works with file paths, streams, and memory sources.
 /// Optionally detects format from filename extension or content.
-/// @tparam T       Input type (e.g., BasicInput, FileStream) with path() and create_stream()
 /// @param input    Input source; format is inferred from extension or content
 /// @param format   File format to use: Unknown (detect by extension),
 ///                 Detect (load entire file and detect by content),

--- a/include/gemmi/mmread.hpp
+++ b/include/gemmi/mmread.hpp
@@ -1,3 +1,7 @@
+/// @file
+/// @brief Auto-detect and read any supported coordinate file format
+///        (PDB, mmCIF, mmJSON, or chemical component).
+
 // Copyright 2017 Global Phasing Ltd.
 //
 // Read any supported coordinate file. Usually, mmread_gz.hpp is preferred.
@@ -16,6 +20,9 @@
 
 namespace gemmi {
 
+/// Detect file format from filename extension.
+/// @param path File path or name
+/// @return Detected format (Pdb, Mmcif, Mmjson) or Unknown if no match
 inline CoorFormat coor_format_from_ext(const std::string& path) {
   if (iends_with(path, ".pdb") || iends_with(path, ".ent"))
     return CoorFormat::Pdb;
@@ -26,7 +33,12 @@ inline CoorFormat coor_format_from_ext(const std::string& path) {
   return CoorFormat::Unknown;
 }
 
-// If it's neither CIF nor JSON nor almost empty - we assume PDB.
+/// Detect file format by examining file content.
+/// Heuristic detection based on content: looks for JSON '{', CIF 'data_',
+/// or falls back to PDB format if neither is found.
+/// @param buf   Pointer to buffer start
+/// @param end   Pointer to buffer end
+/// @return Detected format (Pdb, Mmcif, Mmjson) or Unknown if buffer too small
 inline CoorFormat coor_format_from_content(const char* buf, const char* end) {
   while (buf < end - 8) {
     if (std::isspace(*buf)) {
@@ -45,6 +57,13 @@ inline CoorFormat coor_format_from_content(const char* buf, const char* end) {
   return CoorFormat::Unknown;
 }
 
+/// Build Structure from a CIF document, optionally detecting chemical components.
+/// If possible_chemcomp is true, checks whether the document is a chemical
+/// component file and parses it accordingly; otherwise treats as normal mmCIF.
+/// @param doc                A CIF document; moved into this function
+/// @param possible_chemcomp  If true, check for and handle CCD/monomer library files
+/// @param save_doc           Optional pointer to receive a copy of the document
+/// @return A Structure parsed from the document
 inline Structure make_structure_from_doc(cif::Document&& doc, bool possible_chemcomp,
                                          cif::Document* save_doc=nullptr) {
   if (possible_chemcomp) {
@@ -56,7 +75,16 @@ inline Structure make_structure_from_doc(cif::Document&& doc, bool possible_chem
   return make_structure(std::move(doc), save_doc);
 }
 
-// when reading JSON, the input buffer is changed (as an optimization)
+/// Read a Structure from a memory buffer.
+/// Detects or uses specified format to parse the buffer.
+/// Note: When reading JSON, the input buffer is modified in-place (optimization).
+/// @param data      Pointer to file data; may be modified if JSON format
+/// @param size      Size of data buffer in bytes
+/// @param path      File path or name (used for error messages and format detection)
+/// @param format    File format (Unknown = auto-detect, Detect = content-based detection)
+/// @param save_doc  Optional pointer to receive the parsed CIF document
+/// @return A Structure parsed from the buffer
+/// @throws Throws on parse errors or if format cannot be determined
 inline Structure read_structure_from_memory(char* data, size_t size,
                                             const std::string& path,
                                             CoorFormat format=CoorFormat::Unknown,
@@ -75,13 +103,30 @@ inline Structure read_structure_from_memory(char* data, size_t size,
   fail("wrong format of coordinate file " + path);
 }
 
-// deprecated
+/// @deprecated Use read_structure_from_memory() instead.
+/// Read a Structure from a character array buffer.
+/// @param data      Pointer to file data
+/// @param size      Size of data buffer in bytes
+/// @param path      File path or name
+/// @param save_doc  Optional pointer to receive the parsed CIF document
+/// @return A Structure parsed from the buffer with format auto-detected
 inline Structure read_structure_from_char_array(char* data, size_t size,
                                                 const std::string& path,
                                                 cif::Document* save_doc=nullptr) {
   return read_structure_from_memory(data, size, path, CoorFormat::Unknown, save_doc);
 }
 
+/// Read a Structure from an input source.
+/// Generic template that works with file paths, streams, and memory sources.
+/// Optionally detects format from filename extension or content.
+/// @tparam T       Input type (e.g., BasicInput, FileStream) with path() and create_stream()
+/// @param input    Input source; format is inferred from extension or content
+/// @param format   File format to use: Unknown (detect by extension),
+///                 Detect (load entire file and detect by content),
+///                 or explicit format (Pdb, Mmcif, Mmjson, ChemComp)
+/// @param save_doc Optional pointer to receive the parsed CIF document
+/// @return A Structure parsed from the input
+/// @throws Throws on I/O errors, parse errors, or if format cannot be determined
 template<typename T>
 Structure read_structure(T&& input, CoorFormat format=CoorFormat::Unknown,
                          cif::Document* save_doc=nullptr) {
@@ -113,6 +158,13 @@ Structure read_structure(T&& input, CoorFormat format=CoorFormat::Unknown,
   unreachable();
 }
 
+/// Read a Structure from a file.
+/// Convenience wrapper for read_structure() with a file path.
+/// Format is detected from filename extension by default.
+/// @param path   Path to coordinate file
+/// @param format File format to use: Unknown (detect by extension) or explicit format
+/// @return A Structure parsed from the file
+/// @throws Throws on I/O or parse errors
 inline Structure read_structure_file(const std::string& path,
                                      CoorFormat format=CoorFormat::Unknown) {
   return read_structure(BasicInput(path), format);

--- a/include/gemmi/mmread_gz.hpp
+++ b/include/gemmi/mmread_gz.hpp
@@ -1,3 +1,6 @@
+/// @file
+/// @brief Read coordinate files with optional gzip decompression.
+
 // Copyright 2021 Global Phasing Ltd.
 //
 // Functions for reading possibly gzipped coordinate files.
@@ -11,17 +14,41 @@ namespace gemmi {
 
 namespace cif { struct Document; }
 
+/// Read a Structure from a potentially gzip-compressed coordinate file.
+/// Detects gzip format from filename (.gz extension) or file content,
+/// decompresses if needed, then parses using the appropriate handler.
+/// @param path     Path to coordinate file (may have .gz suffix)
+/// @param format   File format (Unknown = auto-detect from filename or content;
+///                 Detect = force content-based detection after decompression)
+/// @param save_doc Optional pointer to receive the parsed CIF document
+/// @return A Structure parsed from the file
+/// @throws Throws on I/O or parse errors
 GEMMI_DLL Structure read_structure_gz(const std::string& path,
                                       CoorFormat format=CoorFormat::Unknown,
                                       cif::Document* save_doc=nullptr);
 
+/// Read a PDB-format Structure from a potentially gzip-compressed file.
+/// @param path    Path to PDB file (may have .gz suffix)
+/// @param options Parsing options (max line length, handling of TER records, etc.)
+/// @return A Structure parsed from the PDB file
+/// @throws Throws on I/O or parse errors
 GEMMI_DLL Structure read_pdb_gz(const std::string& path,
                                 PdbReadOptions options=PdbReadOptions());
 
+/// Read a chemical component Structure from a potentially gzip-compressed file.
+/// @param path     Path to chemical component file (may have .gz suffix)
+/// @param save_doc Optional pointer to receive the parsed CIF document
+/// @param which    Bitmask of ChemCompModel values to include (default 7 = all)
+/// @return A Structure with the requested coordinate models
+/// @throws Throws on I/O or parse errors, or if not a valid chemical component file
 GEMMI_DLL Structure read_structure_from_chemcomp_gz(const std::string& path,
                                                     cif::Document* save_doc=nullptr,
                                                     int which=7);
 
+/// Detect file format from a filename, accounting for gzip compression.
+/// Strips .gz suffix if present before checking file extension.
+/// @param path File path or name
+/// @return Detected format (Pdb, Mmcif, Mmjson) or Unknown if no match
 GEMMI_DLL CoorFormat coor_format_from_ext_gz(const std::string& path);
 
 } // namespace gemmi

--- a/include/gemmi/pdb.hpp
+++ b/include/gemmi/pdb.hpp
@@ -154,9 +154,9 @@ inline Structure read_pdb_string(const std::string& str,
   return read_pdb_from_memory(str.c_str(), str.length(), name, options);
 }
 
-/// Read a Structure from a PDB input source.
-/// Generic template for file paths, streams, and other input types.
+/// @brief Read a Structure from a PDB input source.
 /// @tparam T      Input type (e.g., BasicInput, FileStream) with path() and create_stream()
+/// Generic template for file paths, streams, and other input types.
 /// @param input   Input source
 /// @param options Parsing options; defaults to standard PDB settings
 /// @return A new Structure parsed from the input

--- a/include/gemmi/pdb.hpp
+++ b/include/gemmi/pdb.hpp
@@ -53,7 +53,7 @@ inline bool is_record_type3(const char* s, const char* record) {
 
 /// Parse REMARK 290 records to extract crystallographic symmetry operations.
 /// REMARK 290 contains the rotation and translation operators (NCS or crystal symmetry).
-/// Returns operations for the Nth instance numbered as 1555, 2555, 3555, etc.
+/// Parses operations in triplet notation (e.g., "X,Y,Z" or "-X,-Y,-Z+1/2").
 /// @param raw_remarks Vector of PDB REMARK record lines
 /// @return Vector of crystallographic operations (Op structures with rotation
 ///         matrix and translation vector)

--- a/include/gemmi/pdb.hpp
+++ b/include/gemmi/pdb.hpp
@@ -1,3 +1,16 @@
+/// @file
+/// @brief Read PDB file format and store coordinates in a Structure.
+///
+/// Implements PDB format parsing per the wwPDB specification v3.3:
+/// https://www.wwpdb.org/documentation/file-format-content/format33/v3.3.html
+///
+/// Enhancements beyond standard PDB:
+/// - Two-character chain IDs (columns 21-22)
+/// - Segment ID parsing (columns 73-76)
+/// - Hybrid-36 serial numbers for > 99,999 atoms
+/// - Hybrid-36 sequence IDs for sequences > 9,999 residues
+/// - Extended REMARK lines (up to 120 characters)
+
 // Copyright 2017 Global Phasing Ltd.
 //
 // Read the PDB file format and store it in Structure.
@@ -18,24 +31,55 @@
 
 namespace gemmi {
 
-/// Compare the first 4 letters of s, ignoring case, with uppercase record.
-/// Both args must have at least 3+1 chars. ' ' and NUL are equivalent in s.
+/// Test if the first 4 columns of a PDB record match a given record type.
+/// Case-insensitive comparison; space and NUL characters in @a s are
+/// treated as equivalent for matching purposes.
+/// @param s      PDB record line (must have >= 4 characters)
+/// @param record Uppercase record name to match (e.g., "ATOM", "HETATM")
+/// @return True if the record names match
 inline bool is_record_type4(const char* s, const char* record) {
   return ialpha4_id(s) == ialpha4_id(record);
 }
-/// for record "TER": "TER ", TER\n, TER\r, TER\t match, TERE, TER1 don't
+
+/// Test if the first 3 columns of a PDB record match a given record type.
+/// Used for 3-character records like TER where the 4th character varies.
+/// Matches "TER ", "TER\n", "TER\r", "TER\t" but not "TERE" or "TER1".
+/// @param s      PDB record line (must have >= 4 characters)
+/// @param record Uppercase record name to match (e.g., "TER", "END")
+/// @return True if the first 3 characters of the record match
 inline bool is_record_type3(const char* s, const char* record) {
   return (ialpha4_id(s) & ~0xf) == ialpha4_id(record);
 }
 
-/// Returns operations corresponding to 1555, 2555, ... N555
+/// Parse REMARK 290 records to extract crystallographic symmetry operations.
+/// REMARK 290 contains the rotation and translation operators (NCS or crystal symmetry).
+/// Returns operations for the Nth instance numbered as 1555, 2555, 3555, etc.
+/// @param raw_remarks Vector of PDB REMARK record lines
+/// @return Vector of crystallographic operations (Op structures with rotation
+///         matrix and translation vector)
 GEMMI_DLL std::vector<Op> read_remark_290(const std::vector<std::string>& raw_remarks);
 
+/// Populate a Structure by parsing a PDB stream.
+/// Parses all ATOM/HETATM records and metadata from the stream, populating
+/// the Structure with models, chains, residues, and atoms.
+/// @param line_reader Stream to read PDB records from
+/// @param source      Source name/path (used in error messages)
+/// @param st          Structure to populate with parsed coordinates
+/// @param options     Parsing options (line length, TER handling, skip remarks, etc.)
+/// @throws Throws on parse errors or invalid records
 GEMMI_DLL void populate_structure_from_pdb_stream(AnyStream& line_reader,
                                                   const std::string& source,
                                                   Structure& st,
                                                   PdbReadOptions options);
 
+/// Populate a Structure by parsing PDB data from a memory buffer.
+/// Convenience wrapper around populate_structure_from_pdb_stream().
+/// @param data    Pointer to PDB file contents
+/// @param size    Size of the buffer in bytes
+/// @param name    Source name/path (used in error messages)
+/// @param st      Structure to populate with parsed coordinates
+/// @param options Parsing options; defaults to standard PDB settings
+/// @throws Throws on parse errors or invalid records
 inline void populate_structure_from_pdb_memory(const char* data, size_t size,
                                                const std::string& name,
                                                Structure& st,
@@ -44,6 +88,13 @@ inline void populate_structure_from_pdb_memory(const char* data, size_t size,
   populate_structure_from_pdb_stream(stream, name, st, options);
 }
 
+/// Populate a Structure by parsing PDB data from a string.
+/// Convenience wrapper around populate_structure_from_pdb_memory().
+/// @param str     String containing PDB file contents
+/// @param name    Source name/path (used in error messages)
+/// @param st      Structure to populate with parsed coordinates
+/// @param options Parsing options; defaults to standard PDB settings
+/// @throws Throws on parse errors or invalid records
 inline void populate_structure_from_pdb_string(const std::string& str,
                                               const std::string& name,
                                               Structure& st,
@@ -51,6 +102,13 @@ inline void populate_structure_from_pdb_string(const std::string& str,
   populate_structure_from_pdb_memory(str.c_str(), str.length(), name, st, options);
 }
 
+/// Read a Structure from a PDB stream.
+/// Convenience wrapper around populate_structure_from_pdb_stream().
+/// @param line_reader Stream to read PDB records from
+/// @param source      Source name/path (used in error messages)
+/// @param options     Parsing options (line length, TER handling, skip remarks, etc.)
+/// @return A new Structure parsed from the PDB stream
+/// @throws Throws on parse errors or invalid records
 inline Structure read_pdb_from_stream(AnyStream& line_reader,
                                       const std::string& source,
                                       PdbReadOptions options) {
@@ -59,12 +117,24 @@ inline Structure read_pdb_from_stream(AnyStream& line_reader,
   return st;
 };
 
+/// Read a Structure from a PDB file.
+/// @param path    Path to PDB file
+/// @param options Parsing options; defaults to standard PDB settings
+/// @return A new Structure parsed from the file
+/// @throws Throws on I/O or parse errors
 inline Structure read_pdb_file(const std::string& path,
                                PdbReadOptions options={}) {
   FileStream stream(path.c_str(), "rb");
   return read_pdb_from_stream(stream, path, options);
 }
 
+/// Read a Structure from a PDB-format memory buffer.
+/// @param data    Pointer to PDB file contents
+/// @param size    Size of the buffer in bytes
+/// @param name    Source name/path (used in error messages)
+/// @param options Parsing options; defaults to standard PDB settings
+/// @return A new Structure parsed from the buffer
+/// @throws Throws on parse errors or invalid records
 inline Structure read_pdb_from_memory(const char* data, size_t size,
                                       const std::string& name,
                                       PdbReadOptions options={}) {
@@ -72,12 +142,25 @@ inline Structure read_pdb_from_memory(const char* data, size_t size,
   return read_pdb_from_stream(stream, name, options);
 }
 
+/// Read a Structure from a PDB-format string.
+/// @param str     String containing PDB file contents
+/// @param name    Source name/path (used in error messages)
+/// @param options Parsing options; defaults to standard PDB settings
+/// @return A new Structure parsed from the string
+/// @throws Throws on parse errors or invalid records
 inline Structure read_pdb_string(const std::string& str,
                                  const std::string& name,
                                  PdbReadOptions options={}) {
   return read_pdb_from_memory(str.c_str(), str.length(), name, options);
 }
 
+/// Read a Structure from a PDB input source.
+/// Generic template for file paths, streams, and other input types.
+/// @tparam T      Input type (e.g., BasicInput, FileStream) with path() and create_stream()
+/// @param input   Input source
+/// @param options Parsing options; defaults to standard PDB settings
+/// @return A new Structure parsed from the input
+/// @throws Throws on I/O or parse errors
 template<typename T>
 inline Structure read_pdb(T&& input, PdbReadOptions options={}) {
   return read_pdb_from_stream(*input.create_stream(), input.path(), options);

--- a/include/gemmi/pirfasta.hpp
+++ b/include/gemmi/pirfasta.hpp
@@ -2,6 +2,9 @@
 //
 // Read sequences from PIR or (multi-)FASTA formats.
 
+/// @file
+/// @brief Parsing of sequence data in PIR and FASTA formats.
+
 #ifndef GEMMI_PIRFASTA_HPP_
 #define GEMMI_PIRFASTA_HPP_
 
@@ -12,12 +15,32 @@
 
 namespace gemmi {
 
+/// @brief A sequence record with header and body.
+///
+/// Represents a single sequence entry from a FASTA or PIR file.
 struct FastaSeq {
+  /// @brief Sequence header/description line (without the '>' prefix).
   std::string header;
+  /// @brief The sequence itself (letters and allowed special characters).
   std::string seq;
 };
 
-// PIR format starts with one of: >P1; >F1; >DL; >DC; >RL; >RC; >XX;
+/// @brief Determine whether a file starts in PIR format.
+///
+/// PIR format is identified by a sequence code at position 1-3 of the first line,
+/// followed by a semicolon at position 3:
+/// - >P1; — Protein
+/// - >F1; — Protein (structure known)
+/// - >DL; — DNA
+/// - >DC; — DNA (structure known)
+/// - >RL; — RNA
+/// - >RC; — RNA (structure known)
+/// - >XX; — Generic/Unknown
+///
+/// FASTA format uses '>something' (arbitrary text after '>').
+///
+/// @param s The first line of a sequence file (expected to start with '>').
+/// @return true if the line matches PIR format syntax, false otherwise.
 inline bool is_pir_format(const std::string& s) {
   return s.length() > 4 && s[0] == '>' && s[3] == ';' && (
         ((s[1] == 'P' || s[1] == 'F') && s[2] == '1') ||
@@ -25,6 +48,26 @@ inline bool is_pir_format(const std::string& s) {
         (s[1] == 'X' && s[2] == 'X'));
 }
 
+/// @brief Parse a string containing PIR or FASTA format sequences.
+///
+/// Supports both FASTA and PIR formats:
+/// - **FASTA format:** Lines start with '>' followed by a description, then sequence lines.
+/// - **PIR format:** Like FASTA, but has a second header line immediately after the first.
+///   The sequence starts on the second line after the primary header.
+///
+/// Sequence parsing rules:
+/// - Alphabetic characters (A-Z, case-insensitive) are included in the sequence.
+/// - Hyphens ('-') represent gaps/insertions.
+/// - Asterisks ('*') mark sequence terminators; content after '*' is not allowed.
+/// - Parentheses '(...)' are allowed (for numbering in PIR); nesting is not allowed.
+/// - Digits are allowed only within parentheses.
+/// - Whitespace is ignored.
+/// - Two or more blank lines separate records.
+///
+/// @param str The complete file content as a string.
+/// @return A vector of FastaSeq records, each with header and sequence.
+/// @throws gemmi::fail() If the input is malformed (no leading '>', unexpected
+///   characters, unmatched parentheses, '*' not at end, etc.).
 inline std::vector<FastaSeq> read_pir_or_fasta(const std::string& str) {
   if (str[0] != '>')
     fail("PIR/FASTA files start with '>'");

--- a/include/gemmi/smcif.hpp
+++ b/include/gemmi/smcif.hpp
@@ -1,6 +1,12 @@
-// Copyright 2018 Global Phasing Ltd.
-//
-// Read small molecule CIF file into SmallStructure (from small.hpp).
+/// @file
+/// @brief Reading and writing small-molecule CIF files into SmallStructure format.
+///
+/// Copyright 2018 Global Phasing Ltd.
+///
+/// Provides functions to parse CIF (Crystallographic Information File) blocks
+/// into Gemmi's SmallStructure representation for small molecules, ligands,
+/// and inorganic crystals. Handles fractional coordinates, anisotropic
+/// displacement parameters, and symmetry operations.
 
 #ifndef GEMMI_SMCIF_HPP_
 #define GEMMI_SMCIF_HPP_
@@ -12,6 +18,14 @@
 
 namespace gemmi {
 
+/// @brief Parses a CIF block into a SmallStructure object.
+/// @param block_ CIF block to parse.
+/// @return SmallStructure containing atomic positions, symmetry, and cell parameters.
+/// Extracts unit cell parameters, space group information (H-M and Hall symbols,
+/// international tables number), symmetry operations, atom sites with fractional
+/// coordinates (occupancy, anisotropic displacement), anisotropic temperature
+/// factors (_atom_site_aniso_*), atom types with dispersion corrections, and
+/// radiation wavelength. Coordinates are assumed to be fractional (CIF convention).
 inline
 SmallStructure make_small_structure_from_block(const cif::Block& block_) {
   using cif::as_number;
@@ -127,6 +141,13 @@ SmallStructure make_small_structure_from_block(const cif::Block& block_) {
   return st;
 }
 
+/// @brief Converts a SmallStructure into a CIF block.
+/// @param st SmallStructure to convert.
+/// @return CIF block with cell parameters, symmetry, and atom sites.
+/// Generates CIF representation with crystallographic cell, space group name,
+/// atom site loop (_atom_site_*), anisotropic displacement loop
+/// (_atom_site_aniso_*), and radiation wavelength if non-zero.
+/// Uses fractional coordinates (CIF convention).
 inline cif::Block make_cif_block_from_small_structure(const SmallStructure& st) {
   cif::Block block;
   block.name = st.name;

--- a/include/gemmi/to_mmcif.hpp
+++ b/include/gemmi/to_mmcif.hpp
@@ -83,7 +83,7 @@ struct MmcifOutputGroups {
   bool tls:1;
   /// @brief Write software used in structure processing (_software category).
   bool software:1;
-  /// @brief @brief Write _atom_site.group_PDB field (ATOM/HETATM classification).
+  /// @brief Write _atom_site.group_PDB field (ATOM/HETATM classification).
   bool group_pdb:1;
   /// @brief Write authentic atom and component IDs (_atom_site.auth_atom_id and auth_comp_id).
   bool auth_all:1;

--- a/include/gemmi/to_mmcif.hpp
+++ b/include/gemmi/to_mmcif.hpp
@@ -2,6 +2,9 @@
 //
 // Create cif::Document (for PDBx/mmCIF file) from Structure.
 
+/// @file
+/// @brief Serialization of Structure to mmCIF/PDBx format.
+
 #ifndef GEMMI_TO_MMCIF_HPP_
 #define GEMMI_TO_MMCIF_HPP_
 
@@ -10,42 +13,83 @@
 
 namespace gemmi {
 
+/// @brief Control which mmCIF data groups to write to the output.
+///
+/// This struct uses bit-fields to selectively enable/disable writing of
+/// individual data blocks and categories in mmCIF output. Each member
+/// corresponds to a major category in the PDBx/mmCIF dictionary.
 struct MmcifOutputGroups {
+  /// @brief Write atom site coordinates (_atom_site category).
   bool atoms:1;
+  /// @brief Write data block name (_entry.id).
   bool block_name:1;
+  /// @brief Write entry metadata (database code, PDB ID).
   bool entry:1;
+  /// @brief Write database status information.
   bool database_status:1;
+  /// @brief Write author information (_audit_author category).
   bool author:1;
+  /// @brief Write unit cell parameters (_cell category).
   bool cell:1;
+  /// @brief Write crystal symmetry (_symmetry category).
   bool symmetry:1;
+  /// @brief Write entity definitions (_entity category).
   bool entity:1;
+  /// @brief Write polymer entity descriptions (_entity_poly category).
   bool entity_poly:1;
+  /// @brief Write structural reference information (_struct_ref category).
   bool struct_ref:1;
+  /// @brief Write chemical component information (_chem_comp category).
   bool chem_comp:1;
+  /// @brief Write experimental method details (_exptl category).
   bool exptl:1;
+  /// @brief Write diffraction data (_diffrn category).
   bool diffrn:1;
+  /// @brief Write reflection statistics (_reflns category).
   bool reflns:1;
+  /// @brief Write refinement details (_refine category).
   bool refine:1;
+  /// @brief Write title and keywords.
   bool title_keywords:1;
+  /// @brief Write NCS (non-crystallographic symmetry) operations.
   bool ncs:1;
+  /// @brief Write structural asymmetric unit information (_struct_asym category).
   bool struct_asym:1;
+  /// @brief Write crystal to fractional coordinate transformation (ORIGX).
   bool origx:1;
+  /// @brief Write secondary structure definitions (_struct_conf category).
   bool struct_conf:1;
+  /// @brief Write beta sheet information (_struct_sheet category).
   bool struct_sheet:1;
+  /// @brief Write biological assembly metadata (_struct_biol category).
   bool struct_biol:1;
+  /// @brief Write pdbx_struct_assembly transformations.
   bool assembly:1;
+  /// @brief Write chemical bond connectivity (_struct_conn category).
   bool conn:1;
+  /// @brief Write cis-peptide information (_struct_mon_prot_cis category).
   bool cis:1;
+  /// @brief Write modified residues (_pdbx_chem_comp_atom_feature for non-standard residues).
   bool modres:1;
+  /// @brief Write binding site information (_struct_site category).
   bool struct_site:1;
+  /// @brief Write matrix scale transformations (_atom_sites_fract_tran category).
   bool scale:1;
+  /// @brief Write atom type scattering info (_atom_type category).
   bool atom_type:1;
+  /// @brief Write polymer sequence information (_entity_poly_seq category).
   bool entity_poly_seq:1;
+  /// @brief Write TLS tensor information (thermal tensor correction).
   bool tls:1;
+  /// @brief Write software used in structure processing (_software category).
   bool software:1;
-  bool group_pdb:1;  // include _atom_site.group_PDB
-  bool auth_all:1;   // include _atom_site.auth_atom_id and auth_comp_id
+  /// @brief @brief Write _atom_site.group_PDB field (ATOM/HETATM classification).
+  bool group_pdb:1;
+  /// @brief Write authentic atom and component IDs (_atom_site.auth_atom_id and auth_comp_id).
+  bool auth_all:1;
 
+  /// @brief Constructor initializing all groups to the same value.
+  /// @param all Set all groups to true (write everything) or false (write nothing).
   explicit MmcifOutputGroups(bool all)
     : atoms(all), block_name(all), entry(all), database_status(all),
       author(all), cell(all), symmetry(all), entity(all), entity_poly(all),
@@ -58,19 +102,55 @@ struct MmcifOutputGroups {
       software(all), group_pdb(all), auth_all(false) {}
 };
 
+/// @brief Populate an existing mmCIF block with data from a Structure.
+/// @param st The Structure to serialize.
+/// @param block The mmCIF block to populate (typically obtained from make_mmcif_block()).
+/// @param groups Selectively enable/disable categories to write.
 GEMMI_DLL void update_mmcif_block(const Structure& st, cif::Block& block,
                                   MmcifOutputGroups groups=MmcifOutputGroups(true));
+
+/// @brief Create a complete mmCIF/PDBx document from a Structure.
+/// @param st The Structure to serialize.
+/// @param groups Selectively enable/disable categories to write.
+/// @return A cif::Document containing a single block with all structural information.
 GEMMI_DLL cif::Document make_mmcif_document(const Structure& st,
                                             MmcifOutputGroups groups=MmcifOutputGroups(true));
+
+/// @brief Create an mmCIF/PDBx block from a Structure.
+/// @param st The Structure to serialize.
+/// @param groups Selectively enable/disable categories to write.
+/// @return A cif::Block containing all selected categories.
 GEMMI_DLL cif::Block make_mmcif_block(const Structure& st,
                                       MmcifOutputGroups groups=MmcifOutputGroups(true));
+
+/// @brief Create an mmCIF block with structural metadata and headers only.
+/// @param st The Structure whose metadata to serialize.
+/// @return A cif::Block containing metadata without atomic coordinates (_atom_site).
 GEMMI_DLL cif::Block make_mmcif_headers(const Structure& st);
+
+/// @brief Add minimal mmCIF category items required for valid output.
+/// @param st The Structure to serialize.
+/// @param block The mmCIF block to populate with essential items.
 GEMMI_DLL void add_minimal_mmcif_data(const Structure& st, cif::Block& block);
 
-// temporarily we use it in crd.cpp
+/// @brief Write NCS (non-crystallographic symmetry) operations to an mmCIF block.
+/// @param st The Structure containing NCS operations.
+/// @param block The mmCIF block to populate.
 GEMMI_DLL void write_ncs_oper(const Structure& st, cif::Block& block);
+
+/// @brief Write chemical connectivity information to an mmCIF block.
+/// @param st The Structure containing connection definitions.
+/// @param block The mmCIF block to populate with _struct_conn items.
 GEMMI_DLL void write_struct_conn(const Structure& st, cif::Block& block);
+
+/// @brief Write cis-peptide information to an mmCIF block.
+/// @param st The Structure containing cis-peptide annotations.
+/// @param block The mmCIF block to populate with _struct_mon_prot_cis items.
 GEMMI_DLL void write_cispeps(const Structure& st, cif::Block& block);
+
+/// @brief Write binding site information to an mmCIF block.
+/// @param st The Structure containing structural site definitions.
+/// @param block The mmCIF block to populate with _struct_site items.
 GEMMI_DLL void write_struct_sites(const Structure& st, cif::Block& block);
 
 } // namespace gemmi

--- a/include/gemmi/to_pdb.hpp
+++ b/include/gemmi/to_pdb.hpp
@@ -2,6 +2,9 @@
 //
 // Writing PDB file format (Structure -> pdb file).
 
+/// @file
+/// @brief Serialization of Structure to PDB fixed-column format.
+
 #ifndef GEMMI_TO_PDB_HPP_
 #define GEMMI_TO_PDB_HPP_
 
@@ -10,25 +13,47 @@
 
 namespace gemmi {
 
+/// @brief Control record types and fields written in PDB output.
+///
+/// Options to selectively enable/disable PDB record types and special
+/// formatting modes when writing Structure to PDB format.
 struct PdbWriteOptions {
-  bool minimal_file = false;    // disable many records not listed below (HEADER, TITLE, ...)
-  bool atom_records = true;     // write atomic models (set to false for headers only)
-  bool seqres_records = true;   // write SEQRES
-  bool ssbond_records = true;   // write SSBOND
-  bool link_records = true;     // write LINK
-  bool cispep_records = true;   // write CISPEP
-  bool cryst1_record = true;    // write CRYST1
-  bool ter_records = true;      // write TER records
-  bool conect_records = false;  // write CONECT - matters only if add_conect() was used
-  bool end_record = true;       // write END
-  bool numbered_ter = true;     // TER record gets own serial number
-  bool ter_ignores_type = false; // put TER after last atom in Chain (even if it's water)
-  bool use_linkr = false;       // use non-standard Refmac LINKR record instead of LINK
-  bool use_link_id = false;     // write Link::link_id instead of distanc in th LINK record
-                                // (when link_id) is not empty. Implied by use_linkr.
-  bool preserve_serial = false; // use serial numbers from Atom.serial
+  /// @brief Minimize output by omitting ancillary records (HEADER, TITLE, REMARK, etc.).
+  bool minimal_file = false;
+  /// @brief Write ATOM/HETATM records with coordinates. If false, omit atomic models.
+  bool atom_records = true;
+  /// @brief Write SEQRES records with polymer sequences.
+  bool seqres_records = true;
+  /// @brief Write SSBOND records (disulfide bonds between cysteines).
+  bool ssbond_records = true;
+  /// @brief Write LINK records for non-disulfide chemical bonds.
+  bool link_records = true;
+  /// @brief Write CISPEP records for cis-peptide bonds.
+  bool cispep_records = true;
+  /// @brief Write CRYST1 record with unit cell and space group information.
+  bool cryst1_record = true;
+  /// @brief Write TER records to mark chain terminations.
+  bool ter_records = true;
+  /// @brief Write CONECT records for inter-residue connectivity (requires add_conect() preprocessing).
+  bool conect_records = false;
+  /// @brief Write END record at end of file.
+  bool end_record = true;
+  /// @brief Assign own serial numbers to TER records if true; reuse ATOM serial if false.
+  bool numbered_ter = true;
+  /// @brief If true, place TER after the last atom in each chain regardless of residue type.
+  /// If false, omit TER after water/heteroatom chains.
+  bool ter_ignores_type = false;
+  /// @brief Use non-standard Refmac LINKR record instead of standard LINK record.
+  bool use_linkr = false;
+  /// @brief Write Link::link_id field in LINK record instead of distance (if link_id is non-empty).
+  /// Automatically enabled by use_linkr.
+  bool use_link_id = false;
+  /// @brief Use atom serial numbers from Atom::serial. If false, generate new serial numbers.
+  bool preserve_serial = false;
   // end of snippet for mol.rst
 
+  /// @brief Factory method: create options for minimal output.
+  /// @return Options with only ATOM records and minimal header information.
   static PdbWriteOptions minimal() {
     PdbWriteOptions opt;
     opt.minimal_file = true;
@@ -39,6 +64,9 @@ struct PdbWriteOptions {
     opt.end_record = false;
     return opt;
   }
+
+  /// @brief Factory method: create options to write header records only (no atomic coordinates).
+  /// @return Options with atom_records disabled and no END record.
   static PdbWriteOptions headers_only() {
     PdbWriteOptions opt;
     opt.atom_records = false;
@@ -47,17 +75,41 @@ struct PdbWriteOptions {
   }
 };
 
-/// record type ATOM/HETATM to use for writing given residue
+/// @brief Determine the PDB record type (ATOM or HETATM) for a given residue.
+///
+/// Uses residue flags and entity type to determine appropriate record type:
+/// - Residues marked 'H' (het flag) use HETATM.
+/// - Standard polymeric residues use ATOM.
+/// - Branched, non-polymer, and water residues use HETATM.
+///
+/// @param res The residue to classify.
+/// @return true if HETATM should be used, false for ATOM.
 GEMMI_DLL bool use_hetatm(const Residue& res);
 
+/// @brief Write a Structure to PDB format on an output stream.
+/// @param st The Structure to serialize.
+/// @param os The output stream to write to.
+/// @param opt Options controlling record types and formatting.
 GEMMI_DLL void write_pdb(const Structure& st, std::ostream& os, PdbWriteOptions opt={});
+
+/// @brief Serialize a Structure to a PDB format string.
+/// @param st The Structure to serialize.
+/// @param opt Options controlling record types and formatting.
+/// @return A std::string containing the complete PDB format output.
 GEMMI_DLL std::string make_pdb_string(const Structure& st, PdbWriteOptions opt={});
 
-// deprecated
+/// @brief Write minimal PDB output (atomic records only, no headers).
+/// @deprecated Use write_pdb(st, os, PdbWriteOptions::minimal()) instead.
+/// @param st The Structure to serialize.
+/// @param os The output stream to write to.
 inline void write_minimal_pdb(const Structure& st, std::ostream& os) {
   write_pdb(st, os, PdbWriteOptions::minimal());
 }
-// deprecated
+
+/// @brief Generate PDB header records only (no atomic coordinates).
+/// @deprecated Use make_pdb_string(st, PdbWriteOptions::headers_only()) instead.
+/// @param st The Structure whose headers to serialize.
+/// @return A std::string containing PDB header records.
 inline std::string make_pdb_headers(const Structure& st) {
   return make_pdb_string(st, PdbWriteOptions::headers_only());
 }


### PR DESCRIPTION
## Summary

This PR adds complete Doxygen API documentation for Gemmi's structure file I/O layer, covering 10 headers:

- `mmcif.hpp` — structure reading from mmCIF (make_structure, make_structure_from_block, ChemCompModel)
- `mmread.hpp` — universal structure reader (read_structure_file, format detection)
- `mmread_gz.hpp` — gzip-aware reading wrappers
- `pdb.hpp` — PDB-format reading (including hybrid-36, REMARK 290 symmetry)
- `to_mmcif.hpp` — structure writing to mmCIF (MmcifOutputGroups with 31 output categories)
- `to_pdb.hpp` — structure writing to PDB (PdbWriteOptions, use_hetatm classification)
- `crd.hpp` — Refmac CRD preparation (setup_for_crd, prepare_refmac_crd)
- `smcif.hpp` — small-molecule CIF reading/writing (fractional coordinates, SmallStructure)
- `mmdb.hpp` — CCP4 MMDB interop layer (copy_to_mmdb, copy_from_mmdb and helpers)
- `pirfasta.hpp` — PIR/FASTA sequence format (is_pir_format, read_pir_or_fasta)

## Documentation standard

- `///` triple-slash Doxygen comments throughout
- Every public entity has `@brief`; non-obvious parameters have `@param`/`@return`/`@throws`/`@tparam`
- Semantics verified against implementations (e.g., save_doc move semantics, use_hetatm three-tier classification, REMARK 290 triplet notation, fractional vs Cartesian coordinates)

## Dependencies

**This PR depends on PR #413** (Doxygen/Breathe infrastructure) being merged first.

It follows PR #414 (core data structures) and PR #415 (CIF handling) in the documentation series.

## Series context

This is PR 4 of a planned series of 10 PRs adding incremental API documentation:

| PR | Branch | Content |
|----|--------|---------|
| #413 | `api-docs/infra` | Build infrastructure (Doxyfile, conf.py, api.rst, readthedocs) |
| #414 | `api-docs/core-structures` | model.hpp, unitcell.hpp, symmetry.hpp, metadata.hpp, elem.hpp, seqid.hpp, resinfo.hpp, small.hpp |
| #415 | `api-docs/cif` | cif.hpp, cifdoc.hpp, read_cif.hpp, to_cif.hpp, to_json.hpp, json.hpp, numb.hpp, ddl.hpp |
| **This PR** | `api-docs/structure-io` | **mmcif.hpp, mmread.hpp, mmread_gz.hpp, pdb.hpp, to_mmcif.hpp, to_pdb.hpp, crd.hpp, smcif.hpp, mmdb.hpp, pirfasta.hpp** |
| PR 5 | `api-docs/reflection` | mtz.hpp, refln.hpp, cif2mtz.hpp, mtz2cif.hpp, and related |
| PR 6 | `api-docs/maps-grids` | grid.hpp, ccp4.hpp, dencalc.hpp, fourier.hpp, and related |
| PR 7 | `api-docs/calculations` | calculate.hpp, neighbor.hpp, sfcalc.hpp, align.hpp, and related |
| PR 8 | `api-docs/chemistry` | chemcomp.hpp, monlib.hpp, topo.hpp, and related |
| PR 9 | `api-docs/scattering-math` | formfact.hpp, math.hpp, cellred.hpp, and related |
| PR 10 | `api-docs/io-utils` | fileutil.hpp, gz.hpp, util.hpp, logger.hpp, and related |

## Attribution

Builds on and credits prior work in PR #402 (Paul Emsley / pemsley). All comments audited/rewritten where needed against actual implementations.