### PR TITLE
fix(grid): restore spacegroup member initialization

### DIFF
--- a/include/gemmi/grid.hpp
+++ b/include/gemmi/grid.hpp
@@ -244,7 +244,7 @@ inline double cubic_interpolation_der(double u, double a, double b, double c, do
 /// Grid indices u, v, w are in the range [0, nu), [0, nv), [0, nw) for valid grids.
 struct GridMeta {
   UnitCell unit_cell;           ///< Unit cell of the crystal
-  const SpaceGroup* spacegroup; ///< Space group (may be nullptr for P1)
+  const SpaceGroup* spacegroup = nullptr;  ///< Space group (may be nullptr for P1)
   int nu = 0, nv = 0, nw = 0;  ///< Grid dimensions
   AxisOrder axis_order = AxisOrder::Unknown;  ///< Grid axis correspondence to a, b, c
 


### PR DESCRIPTION
Restores the initialization of `GridMeta::spacegroup = nullptr` that was
inadvertently removed during the Doxygen documentation PR series (#413-#422).

This uninitialized pointer member could cause undefined behavior if accessed
before being explicitly set.

Related to the partial fix in commit 2c1b0c51, which addressed the same issue
in metadata.hpp and small.hpp.