### PR TITLE
to_mmcif: quote empty pdbx_strand_id so _struct_ref_seq stays readable

### DIFF
--- a/src/to_mmcif.cpp
+++ b/src/to_mmcif.cpp
@@ -721,7 +721,7 @@ void update_mmcif_block(const Structure& st, cif::Block& block, MmcifOutputGroup
           }
           seq_loop.add_row({std::to_string(++counter2),
                             std::to_string(counter),
-                            strand_id->second,  // pdbx_strand_id
+                            qchain(strand_id->second),  // pdbx_strand_id
                             id,
                             label_begin.str(),
                             label_end.str(),

--- a/tests/test_mol.py
+++ b/tests/test_mol.py
@@ -853,6 +853,23 @@ class TestMol(unittest.TestCase):
         ref_seq = doc[0].get_mmcif_category('_struct_ref_seq')
         self.assertEqual(ref_seq['pdbx_strand_id'], ['B'])
 
+    def test_empty_strand_id_struct_ref_seq(self):
+        # A blank chain name (e.g. a PDB file with no chain ID) gives an empty
+        # _struct_ref_seq.pdbx_strand_id. It must be written as a quoted empty
+        # string (''), not dropped: dropping it leaves the loop row one value
+        # short, which makes the whole file unreadable.
+        st = gemmi.read_structure(full_path('1pfe.cif.gz'))
+        for chain in st[0]:
+            if chain.name == 'B':
+                chain.name = ''
+        doc = st.make_mmcif_document()
+        strand_ids = doc[0].find_values('_struct_ref_seq.pdbx_strand_id')
+        self.assertEqual([gemmi.cif.as_string(v) for v in strand_ids], ['A', ''])
+        # Round-trip: writing then re-reading must not raise on a ragged loop.
+        reparsed = gemmi.cif.read_string(doc.as_string())
+        self.assertEqual(reparsed[0].find_values('_struct_ref_seq.pdbx_strand_id')
+                         .str(1), '')
+
     def test_first_conformer(self):
         model = gemmi.read_structure(full_path('1pfe.cif.gz'))[0]
         b = model['B']


### PR DESCRIPTION
### Problem

For a structure with a **blank chain name** (e.g. a PDB file with no chain ID) **and a DBREF**, `make_mmcif_document()` produces an mmCIF file that gemmi itself cannot read back:

```python
import gemmi
st = gemmi.read_structure('1pfe.cif.gz')
for ch in st[0]:
    if ch.name == 'B':
        ch.name = ''          # blank chain name + existing DBREF
doc = st.make_mmcif_document()
gemmi.cif.read_string(doc.as_string())
# ValueError: Wrong number of values in loop _struct_ref_seq.*
```

The empty `_struct_ref_seq.pdbx_strand_id` is written as a **zero-width token**, so the data row ends up with one value fewer than the loop has tags. The loop is ragged, and the whole file becomes unreadable — not just by gemmi's strict reader, but by other consumers too (this surfaced as an MMDB/clipper `Message_fatal` abort in a downstream pipeline reading gemmi-written mmCIF).

It reproduces on current `master` and on the 0.7.5 release. Real-world trigger: legacy single-chain PDB entries with a blank chain ID that carry DBREF records (e.g. PDB `2ACY`).

### Cause

In the `_struct_ref_seq` row builder ([`src/to_mmcif.cpp`](https://github.com/project-gemmi/gemmi/blob/master/src/to_mmcif.cpp)), every field is passed through a sanitising helper (`string_or_qmark`, `string_or_dot`, `.str()`, `qchain`) — **except** `pdbx_strand_id`, which was added raw:

```cpp
seq_loop.add_row({std::to_string(++counter2),
                  std::to_string(counter),
                  strand_id->second,  // pdbx_strand_id  <-- raw; empty -> zero-width token
                  id,
                  ...
```

When `strand_id->second` is empty, nothing is emitted for that column.

### Fix

Wrap it in `qchain()` — exactly what the adjacent `_struct_ref` row already does for `qchain(ent.name)`, and what `qchain`'s own comment describes (chain names that may be empty, written as `''`). The empty value now serialises as `''` (a valid quoted empty string), the loop is well-formed, and it round-trips.

```cpp
qchain(strand_id->second),  // pdbx_strand_id
```

One-line change. Added a regression test (`tests/test_mol.py::test_empty_strand_id_struct_ref_seq`) that blanks a chain name on `1pfe` and asserts the written `_struct_ref_seq` re-reads cleanly; it fails before the change (`Wrong number of values in loop _struct_ref_seq`) and passes after. Full `test_mol.py`/`test_cif.py` pass with no regressions.